### PR TITLE
Allow finding single photos in an album in the URL categorisers

### DIFF
--- a/src/flinumeratr/url_parser.py
+++ b/src/flinumeratr/url_parser.py
@@ -14,7 +14,7 @@ def categorise_flickr_url(url):
     Categorises a Flickr URL, e.g. whether it's a single image, an album,
     a user.
     """
-    u = hyperlink.URL.from_text(url)
+    u = hyperlink.URL.from_text(url.rstrip('/'))
     
     # If this URL doesn't come from Flickr.com, then we can't possibly classify
     # it as a Flickr URL!
@@ -30,7 +30,7 @@ def categorise_flickr_url(url):
             'photo_id': u.path[2],
         }
     
-    if len(u.path) == 5 and u.path[0] == 'photos' and u.path[2].isnumeric() and u.path[3] == 'in' and u.path[4].startswith('photolist-'):
+    if len(u.path) == 5 and u.path[0] == 'photos' and u.path[2].isnumeric() and u.path[3] == 'in' and u.path[4].startswith(('album-', 'photolist-')):
         return {
             'type': 'single_image',
             'url': url,

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -8,23 +8,16 @@ def test_it_rejects_a_url_which_isnt_flickr():
         categorise_flickr_url('https://example.net')
 
 
-def test_it_categorises_a_single_image():
-    url = 'https://www.flickr.com/photos/coast_guard/32812033543'
-    
+@pytest.mark.parametrize(['url', 'photo_id'], [
+    ('https://www.flickr.com/photos/coast_guard/32812033543', '32812033543'),
+    ('https://www.flickr.com/photos/coast_guard/32812033543/in/photolist-RZufqg-ebEcP7-YvCkaU-2dKrfhV-6o5anp-7ZjJuj-fxZTiu-2c1pGwi-JbqooJ-TaNkv5-ehrqn7-2aYFaRh-QLDxJX-2dKrdip-JB7iUz-ehrsNh-2aohZ14-Rgeuo3-JRwKwE-ksAR6U-dZVQ3m-291gkvk-26ynYWn-pHMQyE-a86UD8-9Tpmru-hamg6T-8ZCRFU-QY8amt-2eARQfP-qskFkD-2c1pG1Z-jbCpyF-fTBQDa-a89xfd-a7kYMs-dYjL51-5XJgXY-8caHdL-a89HZd-9GBmft-xy7PBo-sai77d-Vs8YPG-RgevC7-Nv5CF6-e4ZLn9-cPaxqS-9rnjS9-8Y7mhm', '32812033543'),
+    ('https://www.flickr.com/photos/britishlibrary/13874001214/in/album-72157644007437024/', '13874001214'),
+])
+def test_it_categorises_a_single_image(url, photo_id):
     assert categorise_flickr_url(url) == {
         'type': 'single_image',
         'url': url,
-        'photo_id': '32812033543',
-    }
-
-
-def test_it_categorises_a_single_image_in_a_photoset():
-    url = 'https://www.flickr.com/photos/coast_guard/32812033543/in/photolist-RZufqg-ebEcP7-YvCkaU-2dKrfhV-6o5anp-7ZjJuj-fxZTiu-2c1pGwi-JbqooJ-TaNkv5-ehrqn7-2aYFaRh-QLDxJX-2dKrdip-JB7iUz-ehrsNh-2aohZ14-Rgeuo3-JRwKwE-ksAR6U-dZVQ3m-291gkvk-26ynYWn-pHMQyE-a86UD8-9Tpmru-hamg6T-8ZCRFU-QY8amt-2eARQfP-qskFkD-2c1pG1Z-jbCpyF-fTBQDa-a89xfd-a7kYMs-dYjL51-5XJgXY-8caHdL-a89HZd-9GBmft-xy7PBo-sai77d-Vs8YPG-RgevC7-Nv5CF6-e4ZLn9-cPaxqS-9rnjS9-8Y7mhm'
-    
-    assert categorise_flickr_url(url) == {
-        'type': 'single_image',
-        'url': url,
-        'photo_id': '32812033543',
+        'photo_id': photo_id,
     }
 
 


### PR DESCRIPTION
It turns out photos can be in photosets or in albums; my previous code was only expecting them to be in photosets and so it broke when it saw a photo in the latter.