### PR TITLE
Add a basic command-line interface for setting port/debug/etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Then you can run the app by running `flinumeratr` with your API key passed as an
 $ FLICKR_API_KEY=<KEY> flinumeratr
 ```
 
+You can run `flinumeratr --help` to see a few other options.
+
 If you want to run tests, install the dev dependencies and run py.test:
 
 ```console

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     python_requires=">=3.7",
     entry_points={
         "console_scripts": [
-            "flinumeratr = flinumeratr.app:main",
+            "flinumeratr = flinumeratr.cli:main",
         ]
     },
 )

--- a/src/flinumeratr/app.py
+++ b/src/flinumeratr/app.py
@@ -174,7 +174,3 @@ def see_photos():
             data={**categorised_url, **photos},
             label=category_label,
         )
-
-
-def main():
-    app.run(debug=True)

--- a/src/flinumeratr/cli.py
+++ b/src/flinumeratr/cli.py
@@ -1,0 +1,18 @@
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="flinumeratr",
+        description="Run a local version of flinumeratr, a toy to help you pull images out of Flickr.",
+    )
+
+    parser.add_argument("--port", help="the port to bind to", type=int, default=5000)
+    parser.add_argument("--host", default="127.0.0.1", help="the interface to bind to")
+    parser.add_argument("--debug", action="store_true", help="run in debug mode")
+
+    args = parser.parse_args()
+
+    from flinumeratr.app import app
+
+    app.run(debug=args.debug, port=args.port, host=args.host)


### PR DESCRIPTION
This makes the local Flask app just a bit nicer to work with, e.g. you can pick different ports and you can run it in debug or in release mode. Nothing fancy but good enough for now.

Closes #10.