### PR TITLE
Add support for granularity in dates

### DIFF
--- a/src/flinumeratr/app.py
+++ b/src/flinumeratr/app.py
@@ -14,12 +14,15 @@ from flinumeratr.enumerator import (
     NotAFlickrUrl,
     UnrecognisedUrl,
 )
+from flinumeratr.filters import render_date_taken
 from flinumeratr.flickr_api import FlickrApi, ResourceNotFound
 
 
 app = Flask(__name__)
 
 app.config["SECRET_KEY"] = secrets.token_hex()
+
+app.add_template_filter(render_date_taken)
 
 try:
     api_key = os.environ["FLICKR_API_KEY"]

--- a/src/flinumeratr/filters.py
+++ b/src/flinumeratr/filters.py
@@ -1,0 +1,26 @@
+class TakenDateGranularity:
+    """
+    Named constants for Flickr "Taken date" granularity.
+
+    See https://www.flickr.com/services/api/misc.dates.html
+    """
+
+    Day = "0"
+    Month = "4"
+    Year = "6"
+    Circa = "8"
+
+
+def render_date_taken(date_taken):
+    if date_taken["unknown"]:
+        return
+    elif date_taken["granularity"] == TakenDateGranularity.Day:
+        return f"on {date_taken['value'].strftime('%B %-d, %Y')}"
+    elif date_taken["granularity"] == TakenDateGranularity.Month:
+        return f"in {date_taken['value'].strftime('%B %Y')}"
+    elif date_taken["granularity"] == TakenDateGranularity.Year:
+        return f"sometime in {date_taken['value'].strftime('%Y')}"
+    elif date_taken["granularity"] == TakenDateGranularity.Circa:
+        return f"circa {date_taken['value'].strftime('%Y')}"
+    else:
+        raise ValueError(f"Unrecognised granularity: {date_taken['granularity']}")

--- a/src/flinumeratr/templates/see_photos.html
+++ b/src/flinumeratr/templates/see_photos.html
@@ -134,7 +134,9 @@
         </h5>
       {% endif %}
       <p>
-        taken {{ p.date_taken.strftime("%-d %B %Y") }}<br/>
+        {% if not p.date_taken.unknown %}
+        taken {{ p.date_taken | render_date_taken }}<br/>
+        {% endif %}
         uploaded {{ p.date_posted.strftime("%-d %B %Y") }}
       </p>
 			<div class="license">

--- a/src/flinumeratr/templates/see_photos.html
+++ b/src/flinumeratr/templates/see_photos.html
@@ -137,7 +137,7 @@
         {% if not p.date_taken.unknown %}
         taken {{ p.date_taken | render_date_taken }}<br/>
         {% endif %}
-        uploaded {{ p.date_posted.strftime("%-d %B %Y") }}
+        uploaded on {{ p.date_posted.strftime("%B %-d, %Y") }}
       </p>
 			<div class="license">
         {% include "_license.html" %}

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -14,7 +14,11 @@ GET_SINGLE_PHOTO = {
     "title": "Puppy Kisses",
     "owner": "Coast Guard",
     "date_posted": datetime.datetime(2017, 3, 24, 17, 27, 52),
-    "date_taken": datetime.datetime(2017, 2, 17, 0, 0),
+    "date_taken": {
+        "value": datetime.datetime(2017, 2, 17, 0, 0),
+        "granularity": "0",
+        "unknown": False,
+    },
     "sizes": [
         {
             "height": 75,
@@ -135,7 +139,11 @@ GET_PHOTOS_IN_PHOTOSET = {
     "photos": [
         {
             "date_posted": datetime.datetime(2013, 12, 5, 18, 55, 30),
-            "date_taken": datetime.datetime(2013, 12, 5, 18, 55, 30),
+            "date_taken": {
+                "value": datetime.datetime(2013, 12, 5, 18, 55, 30),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {
                 "name": "No known copyright restrictions",
                 "url": "https://www.flickr.com/commons/usage/",
@@ -186,7 +194,11 @@ GET_PHOTOS_IN_PHOTOSET = {
         },
         {
             "date_posted": datetime.datetime(2013, 11, 24, 13, 39, 48),
-            "date_taken": datetime.datetime(2013, 11, 24, 13, 39, 48),
+            "date_taken": {
+                "value": datetime.datetime(2013, 11, 24, 13, 39, 48),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {
                 "name": "No known copyright restrictions",
                 "url": "https://www.flickr.com/commons/usage/",
@@ -238,7 +250,11 @@ GET_PHOTOS_IN_PHOTOSET = {
         },
         {
             "date_posted": datetime.datetime(2013, 12, 1, 7, 27, 24),
-            "date_taken": datetime.datetime(2013, 12, 1, 7, 27, 24),
+            "date_taken": {
+                "value": datetime.datetime(2013, 12, 1, 7, 27, 24),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {
                 "name": "No known copyright restrictions",
                 "url": "https://www.flickr.com/commons/usage/",
@@ -297,7 +313,11 @@ GET_PUBLIC_PHOTOS_BY_PERSON = {
     "photos": [
         {
             "date_posted": datetime.datetime(2023, 9, 16, 15, 35, 25),
-            "date_taken": datetime.datetime(2023, 9, 16, 17, 33, 41),
+            "date_taken": {
+                "value": datetime.datetime(2023, 9, 16, 17, 33, 41),
+                "granularity": "0",
+                "unknown": True,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Alexander Lauterbach Photography",
             "sizes": [
@@ -335,7 +355,11 @@ GET_PUBLIC_PHOTOS_BY_PERSON = {
         },
         {
             "date_posted": datetime.datetime(2023, 8, 26, 15, 53, 2),
-            "date_taken": datetime.datetime(2023, 6, 13, 8, 7, 52),
+            "date_taken": {
+                "value": datetime.datetime(2023, 6, 13, 8, 7, 52),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Alexander Lauterbach Photography",
             "sizes": [
@@ -373,7 +397,11 @@ GET_PUBLIC_PHOTOS_BY_PERSON = {
         },
         {
             "date_posted": datetime.datetime(2023, 8, 5, 15, 33, 10),
-            "date_taken": datetime.datetime(2023, 6, 8, 22, 3, 23),
+            "date_taken": {
+                "value": datetime.datetime(2023, 6, 8, 22, 3, 23),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Alexander Lauterbach Photography",
             "sizes": [
@@ -411,7 +439,11 @@ GET_PUBLIC_PHOTOS_BY_PERSON = {
         },
         {
             "date_posted": datetime.datetime(2023, 7, 15, 13, 52, 17),
-            "date_taken": datetime.datetime(2023, 6, 7, 21, 46, 23),
+            "date_taken": {
+                "value": datetime.datetime(2023, 6, 7, 21, 46, 23),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Alexander Lauterbach Photography",
             "sizes": [
@@ -449,7 +481,11 @@ GET_PUBLIC_PHOTOS_BY_PERSON = {
         },
         {
             "date_posted": datetime.datetime(2023, 6, 24, 15, 20, 43),
-            "date_taken": datetime.datetime(2023, 6, 22, 16, 1, 17),
+            "date_taken": {
+                "value": datetime.datetime(2023, 6, 22, 16, 1, 17),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Alexander Lauterbach Photography",
             "sizes": [
@@ -495,7 +531,11 @@ GET_PHOTOS_IN_GROUP_POOL = {
     "photos": [
         {
             "date_posted": datetime.datetime(2023, 10, 3, 7, 24, 45),
-            "date_taken": datetime.datetime(2022, 9, 29, 13, 45, 46),
+            "date_taken": {
+                "value": datetime.datetime(2022, 9, 29, 13, 45, 46),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "www.nbfotos.de",
             "sizes": [
@@ -540,7 +580,11 @@ GET_PHOTOS_IN_GROUP_POOL = {
         },
         {
             "date_posted": datetime.datetime(2023, 10, 3, 7, 24, 44),
-            "date_taken": datetime.datetime(2022, 9, 29, 13, 43, 25),
+            "date_taken": {
+                "value": datetime.datetime(2022, 9, 29, 13, 43, 25),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "www.nbfotos.de",
             "sizes": [
@@ -585,7 +629,11 @@ GET_PHOTOS_IN_GROUP_POOL = {
         },
         {
             "date_posted": datetime.datetime(2023, 10, 3, 7, 24, 43),
-            "date_taken": datetime.datetime(2022, 9, 29, 12, 35, 49),
+            "date_taken": {
+                "value": datetime.datetime(2022, 9, 29, 12, 35, 49),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "www.nbfotos.de",
             "sizes": [
@@ -630,7 +678,11 @@ GET_PHOTOS_IN_GROUP_POOL = {
         },
         {
             "date_posted": datetime.datetime(2023, 10, 3, 6, 52, 29),
-            "date_taken": datetime.datetime(2023, 9, 30, 15, 33, 9),
+            "date_taken": {
+                "value": datetime.datetime(2023, 9, 30, 15, 33, 9),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Vid Pogacnik",
             "sizes": [
@@ -668,7 +720,11 @@ GET_PHOTOS_IN_GROUP_POOL = {
         },
         {
             "date_posted": datetime.datetime(2023, 10, 3, 6, 52, 29),
-            "date_taken": datetime.datetime(2023, 9, 30, 17, 21, 38),
+            "date_taken": {
+                "value": datetime.datetime(2023, 9, 30, 17, 21, 38),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Vid Pogacnik",
             "sizes": [
@@ -714,7 +770,11 @@ GET_PHOTOS_IN_GALLERY = {
     "photos": [
         {
             "date_posted": datetime.datetime(2023, 9, 18, 12, 35, 43),
-            "date_taken": datetime.datetime(2022, 11, 9, 2, 23, 38),
+            "date_taken": {
+                "value": datetime.datetime(2022, 11, 9, 2, 23, 38),
+                "granularity": "0",
+                "unknown": True,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "mimiezinne",
             "sizes": [
@@ -759,7 +819,11 @@ GET_PHOTOS_IN_GALLERY = {
         },
         {
             "date_posted": datetime.datetime(2023, 9, 16, 16, 27, 43),
-            "date_taken": datetime.datetime(2019, 12, 17, 7, 10, 34),
+            "date_taken": {
+                "value": datetime.datetime(2019, 12, 17, 7, 10, 34),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "ayeshakazim",
             "sizes": [
@@ -804,7 +868,11 @@ GET_PHOTOS_IN_GALLERY = {
         },
         {
             "date_posted": datetime.datetime(2023, 9, 6, 17, 57, 40),
-            "date_taken": datetime.datetime(2023, 9, 6, 8, 51, 52),
+            "date_taken": {
+                "value": datetime.datetime(2023, 9, 6, 8, 51, 52),
+                "granularity": "0",
+                "unknown": True,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "crosscapturesphotography",
             "sizes": [
@@ -849,7 +917,11 @@ GET_PHOTOS_IN_GALLERY = {
         },
         {
             "date_posted": datetime.datetime(2023, 9, 19, 21, 16, 13),
-            "date_taken": datetime.datetime(2017, 9, 10, 18, 5, 14),
+            "date_taken": {
+                "value": datetime.datetime(2017, 9, 10, 18, 5, 14),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "dbenson927",
             "sizes": [
@@ -894,7 +966,11 @@ GET_PHOTOS_IN_GALLERY = {
         },
         {
             "date_posted": datetime.datetime(2023, 9, 7, 21, 13, 23),
-            "date_taken": datetime.datetime(2022, 1, 24, 17, 39, 4),
+            "date_taken": {
+                "value": datetime.datetime(2022, 1, 24, 17, 39, 4),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "kamerinchambers",
             "sizes": [
@@ -947,7 +1023,11 @@ GET_PHOTOS_WITH_TAG = {
     "photos": [
         {
             "date_posted": datetime.datetime(2017, 7, 2, 10, 47, 21),
-            "date_taken": datetime.datetime(2017, 6, 19, 18, 28, 50),
+            "date_taken": {
+                "value": datetime.datetime(2017, 6, 19, 18, 28, 50),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "SJM_1974",
             "sizes": [
@@ -992,7 +1072,11 @@ GET_PHOTOS_WITH_TAG = {
         },
         {
             "date_posted": datetime.datetime(2016, 6, 11, 17, 20, 7),
-            "date_taken": datetime.datetime(2016, 5, 17, 14, 13, 47),
+            "date_taken": {
+                "value": datetime.datetime(2016, 5, 17, 14, 13, 47),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Jimmie48 Tennis Photography",
             "sizes": [
@@ -1037,7 +1121,11 @@ GET_PHOTOS_WITH_TAG = {
         },
         {
             "date_posted": datetime.datetime(2016, 5, 11, 20, 45, 42),
-            "date_taken": datetime.datetime(2016, 5, 5, 14, 20, 44),
+            "date_taken": {
+                "value": datetime.datetime(2016, 5, 5, 14, 20, 44),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Jimmie48 Tennis Photography",
             "sizes": [
@@ -1082,7 +1170,11 @@ GET_PHOTOS_WITH_TAG = {
         },
         {
             "date_posted": datetime.datetime(2015, 11, 15, 23, 54, 14),
-            "date_taken": datetime.datetime(2014, 6, 12, 13, 36, 13),
+            "date_taken": {
+                "value": datetime.datetime(2014, 6, 12, 13, 36, 13),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "stevez10is",
             "sizes": [
@@ -1127,7 +1219,11 @@ GET_PHOTOS_WITH_TAG = {
         },
         {
             "date_posted": datetime.datetime(2015, 7, 11, 18, 54, 22),
-            "date_taken": datetime.datetime(2015, 6, 24, 14, 9, 53),
+            "date_taken": {
+                "value": datetime.datetime(2015, 6, 24, 14, 9, 53),
+                "granularity": "0",
+                "unknown": False,
+            },
             "license": {"name": "All Rights Reserved", "url": ""},
             "owner": "Jimmie48 Tennis Photography",
             "sizes": [

--- a/tests/fixtures/cassettes/test_get_single_photo_info_with_unknown_date_taken.yml
+++ b/tests/fixtures/cassettes/test_get_single_photo_info_with_unknown_date_taken.yml
@@ -1,0 +1,215 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=25868667441
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+      id=\"25868667441\" secret=\"55b0c0138a\" server=\"1702\" farm=\"2\" dateuploaded=\"1458576973\"
+      isfavorite=\"0\" license=\"0\" safety_level=\"0\" rotation=\"0\" originalsecret=\"3e6716a4d4\"
+      originalformat=\"jpg\" views=\"191\" media=\"photo\">\n\t<owner nsid=\"140375060@N02\"
+      username=\"CD PIX\" realname=\"Colin\" location=\"Northern Ireland\" iconserver=\"1523\"
+      iconfarm=\"2\" path_alias=\"\">\n\t\t<gift gift_eligible=\"1\" new_flow=\"1\">\n\t\t\t<eligible_durations
+      />\n\t\t\t<eligible_durations />\n\t\t\t<eligible_durations />\n\t\t</gift>\n\t</owner>\n\t<title>Kirkistown
+      1979 (13)</title>\n\t<description>Joey Dunlop</description>\n\t<visibility ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1458576973\" taken=\"2016-03-21
+      16:15:39\" takengranularity=\"0\" takenunknown=\"1\" lastupdate=\"1681933352\"
+      />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+      cancomment=\"1\" canaddmeta=\"1\" />\n\t<usage candownload=\"1\" canblog=\"0\"
+      canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
+      haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"140354712-25868667441-9022895\"
+      author=\"140375060@N02\" authorname=\"CD PIX\" raw=\"Kirkistown\" machine_tag=\"0\">kirkistown</tag>\n\t\t<tag
+      id=\"140354712-25868667441-689896\" author=\"140375060@N02\" authorname=\"CD
+      PIX\" raw=\"Joeydunlop\" machine_tag=\"0\">joeydunlop</tag>\n\t\t<tag id=\"140354712-25868667441-5060\"
+      author=\"140375060@N02\" authorname=\"CD PIX\" raw=\"Joey\" machine_tag=\"0\">joey</tag>\n\t\t<tag
+      id=\"140354712-25868667441-132871\" author=\"140375060@N02\" authorname=\"CD
+      PIX\" raw=\"Dunlop\" machine_tag=\"0\">dunlop</tag>\n\t</tags>\n\t<urls>\n\t\t<url
+      type=\"photopage\">https://www.flickr.com/photos/140375060@N02/25868667441/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '744'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 13 Oct 2023 09:04:47 GMT
+      Via:
+      - 1.1 e6c7f319441995c0d64be3f90dad8370.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _oEaWJmLzz6JpeMOOUH5LMRb03jI4-jhN7HENUi7a_p2B0OJxkkLrw==
+      X-Amz-Cf-Pop:
+      - LHR61-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 12-Nov-2023 09:04:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 12-Nov-2023 09:04:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=25868667441
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<sizes
+      canblog=\"0\" canprint=\"0\" candownload=\"1\">\n\t<size label=\"Square\" width=\"75\"
+      height=\"75\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_s.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/sq/\" media=\"photo\"
+      />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_q.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/q/\" media=\"photo\"
+      />\n\t<size label=\"Thumbnail\" width=\"100\" height=\"81\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_t.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/t/\" media=\"photo\"
+      />\n\t<size label=\"Small\" width=\"240\" height=\"194\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_m.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/s/\" media=\"photo\"
+      />\n\t<size label=\"Small 320\" width=\"320\" height=\"259\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_n.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/n/\" media=\"photo\"
+      />\n\t<size label=\"Small 400\" width=\"400\" height=\"324\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_w.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/w/\" media=\"photo\"
+      />\n\t<size label=\"Medium\" width=\"500\" height=\"405\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/m/\" media=\"photo\"
+      />\n\t<size label=\"Medium 640\" width=\"640\" height=\"518\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_z.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/z/\" media=\"photo\"
+      />\n\t<size label=\"Medium 800\" width=\"800\" height=\"648\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_c.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/c/\" media=\"photo\"
+      />\n\t<size label=\"Large\" width=\"1024\" height=\"829\" source=\"https://live.staticflickr.com/1702/25868667441_55b0c0138a_b.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/l/\" media=\"photo\"
+      />\n\t<size label=\"Large 1600\" width=\"1600\" height=\"1295\" source=\"https://live.staticflickr.com/1702/25868667441_186bd0b855_h.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/h/\" media=\"photo\"
+      />\n\t<size label=\"Original\" width=\"1600\" height=\"1295\" source=\"https://live.staticflickr.com/1702/25868667441_3e6716a4d4_o.jpg\"
+      url=\"https://www.flickr.com/photos/140375060@N02/25868667441/sizes/o/\" media=\"photo\"
+      />\n</sizes>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '473'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 13 Oct 2023 09:04:47 GMT
+      Via:
+      - 1.1 e6c7f319441995c0d64be3f90dad8370.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - kcO3ybg6sEy9dxz6dgoUSoCWxu04ueOex4-jOGT1uqw1DiPGv__PuA==
+      X-Amz-Cf-Pop:
+      - LHR61-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 12-Nov-2023 09:04:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '395'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 13 Oct 2023 09:04:47 GMT
+      Via:
+      - 1.1 e6c7f319441995c0d64be3f90dad8370.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - epQdHBLJhqGdR46QQJWU6EfKRcFLwZCta_tigoLwhGxHUiTa9KctMw==
+      X-Amz-Cf-Pop:
+      - LHR61-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 12-Nov-2023 09:04:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,79 @@
+import datetime
+
+import pytest
+
+from flinumeratr.filters import render_date_taken
+
+
+@pytest.mark.parametrize(
+    ["date_taken", "expected_output"],
+    [
+        # Based on https://www.flickr.com/photos/184374196@N07/53069446440
+        (
+            {
+                "granularity": "0",
+                "value": datetime.datetime(2023, 2, 20, 23, 31, 31),
+                "unknown": False,
+            },
+            "on February 20, 2023",
+        ),
+        # Based on https://www.flickr.com/photos/schlesinger_library/13270291833/
+        (
+            {
+                "granularity": "0",
+                "value": datetime.datetime(2014, 3, 7, 11, 44, 16),
+                "unknown": False,
+            },
+            "on March 7, 2014",
+        ),
+        # Based on https://www.flickr.com/photos/normko/361850789
+        (
+            {
+                "granularity": "4",
+                "value": datetime.datetime(1970, 3, 1, 0, 0, 0),
+                "unknown": False,
+            },
+            "in March 1970",
+        ),
+        # Based on https://www.flickr.com/photos/nationalarchives/5240741057
+        (
+            {
+                "granularity": "6",
+                "value": datetime.datetime(1950, 1, 1, 0, 0, 0),
+                "unknown": False,
+            },
+            "sometime in 1950",
+        ),
+        # Based on https://www.flickr.com/photos/nlireland/6975991819
+        (
+            {
+                "granularity": "8",
+                "value": datetime.datetime(1910, 1, 1, 0, 0, 0),
+                "unknown": False,
+            },
+            "circa 1910",
+        ),
+        # Based on https://www.flickr.com/photos/140375060@N02/25868667441/
+        (
+            {
+                "granularity": "0",
+                "value": datetime.datetime(2016, 3, 21, 16, 15, 39),
+                "unknown": True,
+            },
+            None,
+        ),
+    ],
+)
+def test_render_date_taken(date_taken, expected_output):
+    assert render_date_taken(date_taken) == expected_output
+
+
+def test_render_date_taken_fails_with_unrecognised_granularity():
+    with pytest.raises(ValueError):
+        render_date_taken(
+            date_taken={
+                "granularity": -1,
+                "value": datetime.datetime.now(),
+                "unknown": False,
+            }
+        )

--- a/tests/test_flickr_api.py
+++ b/tests/test_flickr_api.py
@@ -104,6 +104,12 @@ def test_get_single_photo_info(api):
     assert info == GET_SINGLE_PHOTO
 
 
+def test_get_single_photo_info_with_unknown_date_taken(api):
+    info = get_single_photo_info(api, photo_id="25868667441")
+
+    assert info["date_taken"]["unknown"]
+
+
 @pytest.mark.parametrize(
     ["method", "params"],
     [


### PR DESCRIPTION
Closes #44 

Previously we'd render the "date taken" as a day/month/year value, even if the Flickr API was telling us that (1) the date taken wasn't known to that level of granularity or (2) the date taken wasn't known at all.

This patch has us look at the granularity on the "date taken" (see https://www.flickr.com/services/api/misc.dates.html) and show the date taken in results with an appropriate level of granularity.