### PR TITLE
Make sure we capture coverage data for the `tests` directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,8 @@
 [run]
 branch = True
-source = flinumeratr
-# TODO: Capture coverage data for the 'tests' directory
+source =
+  flinumeratr
+  tests
 
 [report]
 show_missing = true

--- a/tests/test_flickr_api.py
+++ b/tests/test_flickr_api.py
@@ -1,6 +1,3 @@
-import datetime
-import json
-
 import pytest
 
 from flinumeratr.flickr_api import (
@@ -26,12 +23,6 @@ from fixtures import (
     GET_PHOTOS_WITH_TAG,
     GET_SINGLE_PHOTO,
 )
-
-
-class DatetimeEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
 
 
 def test_it_throws_a_flickr_api_exception_for_errors(api):


### PR DESCRIPTION
And lo and behold, it told me about some test code that wasn't being used! So I can go ahead and clean that up.