### PR TITLE
Fix the infoboxes; write some tests for the Flask app

### DIFF
--- a/src/flinumeratr/templates/see_photos.html
+++ b/src/flinumeratr/templates/see_photos.html
@@ -78,29 +78,27 @@
   .infobox {}
 </style>
 
-{% if data.type == "people" %}
+{% if data.type == "user" %}
   <p id="infobox">
     This URL shows the photos taken by
     <a href="https://www.flickr.com/photos/{{ data.user_info.user_id }}">{{ data.user_info.realname or data.user_info.username }}</a>,
     who has posted {{ data.total_photos | intcomma }}&nbsp;photo{% if data.total_photos != 1 %}s{% endif %}</span>.
   </p>
-{% elif data.type == "photoset" %}
+{% elif data.type == "album" %}
   <p id="infobox">
-    This URL shows the photos in the <a href="{{ flickr_url }}">{{ data.photoset_title }}</a> album,
-    which was created by <a href="/see_photos?flickr_url=https://www.flickr.com/photos/{{ data.user_info.user_id }}">{{ data.user_info.realname or data.user_info.username }}</a>.
+    This URL shows the photos in the <a href="{{ flickr_url }}">{{ data.photoset_title }}</a> album, which was created by <a href="/see_photos?flickr_url=https://www.flickr.com/photos/{{ data.user_info.user_id }}">{{ data.user_info.realname or data.user_info.username }}</a>.
     It contains {{ data.total_photos | intcomma }}&nbsp;photo{% if data.total_photos != 1 %}s{% endif %}</span>.
   </p>
 {% elif data.type == "group" %}
   <p id="infobox">
-    This URL shows the photos in the <a href="{{ flickr_url }}">{{ data.group_name }}</a> group pool,
-    which contains {{ data.total_photos | intcomma }}&nbsp;photo{% if data.total_photos != 1 %}s{% endif %}</span>.
+    This URL shows the photos in the <a href="{{ flickr_url }}">{{ data.group_name }}</a> group pool, which contains {{ data.total_photos | intcomma }}&nbsp;photo{% if data.total_photos != 1 %}s{% endif %}</span>.
   </p>
-{% elif data.type == "galleries" %}
+{% elif data.type == "gallery" %}
   <p id="infobox">
     This URL shows the photos in the <a href="{{ flickr_url }}">{{ data.gallery_title }}</a> gallery,
     which contains {{ data.total_photos | intcomma }}&nbsp;photo{% if data.total_photos != 1 %}s{% endif %}</span>.
   </p>
-{% elif data.type == "tags" %}
+{% elif data.type == "tag" %}
   <p id="infobox">
     This URL shows photos tagged with <a href="{{ flickr_url }}">{{ data.tag }}</a>.
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,18 @@ def api(cassette_name):
         filter_query_parameters=["api_key"],
     ):
         yield FlickrApi(api_key=os.environ.get("FLICKR_API_KEY", "<REDACTED>"))
+
+
+@pytest.fixture()
+def client():
+    """
+    Creates an instance of the app for use in testing.
+
+    See https://flask.palletsprojects.com/en/3.0.x/testing/#fixtures
+    """
+    from flinumeratr.app import app
+
+    app.config["TESTING"] = True
+
+    with app.test_client() as client:
+        yield client

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box.https---flickr.com-photos-tags-thatch--expected_text5.yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box.https---flickr.com-photos-tags-thatch--expected_text5.yml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Cowner_name%2Cpath_alias%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o&method=flickr.photos.search&page=1&per_page=10&sort=interestingness-desc&tags=thatch
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+      page=\"1\" pages=\"3224\" perpage=\"10\" total=\"32231\">\n\t<photo id=\"52312186930\"
+      owner=\"114111770@N03\" secret=\"ba282fe74a\" server=\"65535\" farm=\"66\" title=\"What
+      lies hidden?\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1661501259\"
+      datetaken=\"2022-05-14 17:53:22\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"jpotto\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/52312186930_ba282fe74a_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/52312186930_ba282fe74a_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/52312186930_ba282fe74a_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/52312186930_ba282fe74a.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/52312186930_74e846ea7e_o.jpg\"
+      height_o=\"3456\" width_o=\"5184\" pathalias=\"\" />\n\t<photo id=\"47857099162\"
+      owner=\"41622708@N00\" secret=\"609bc5d85c\" server=\"65535\" farm=\"66\" title=\"Senufo
+      fetish house whose roof gets a new layer every year, Savanes district, Niofoin,
+      Ivory Coast\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1558540195\"
+      datetaken=\"2019-05-03 11:06:25\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Eric Lafforgue\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/47857099162_609bc5d85c_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/47857099162_609bc5d85c_t.jpg\"
+      height_t=\"71\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/47857099162_609bc5d85c_m.jpg\"
+      height_s=\"170\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/47857099162_609bc5d85c.jpg\"
+      height_m=\"353\" width_m=\"500\" pathalias=\"mytripsmypics\" />\n\t<photo id=\"30194923077\"
+      owner=\"96378267@N04\" secret=\"6841192ff4\" server=\"1951\" farm=\"2\" title=\"The
+      Cuckoo Inn Hamptworth Wiltshire UK\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1538824909\" datetaken=\"2018-10-02 14:50:03\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"davidseall\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/1951/30194923077_6841192ff4_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/1951/30194923077_6841192ff4_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/1951/30194923077_6841192ff4_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/1951/30194923077_6841192ff4.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"\" />\n\t<photo id=\"33114209750\"
+      owner=\"147467413@N04\" secret=\"821376a6c0\" server=\"3764\" farm=\"4\" title=\"Gold
+      Hill\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1489784444\"
+      datetaken=\"2012-10-06 15:36:58\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"carolephillips1\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/3764/33114209750_821376a6c0_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/3764/33114209750_821376a6c0_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/3764/33114209750_821376a6c0_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/3764/33114209750_821376a6c0.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/3764/33114209750_14bd742b22_o.jpg\"
+      height_o=\"2448\" width_o=\"3264\" pathalias=\"\" />\n\t<photo id=\"32370577170\"
+      owner=\"39462456@N02\" secret=\"aa077700ff\" server=\"559\" farm=\"1\" title=\"Pamphill\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1486409210\"
+      datetaken=\"1982-04-13 00:00:12\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"brightondj\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/559/32370577170_aa077700ff_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/559/32370577170_aa077700ff_t.jpg\"
+      height_t=\"71\" width_t=\"100\" url_s=\"https://live.staticflickr.com/559/32370577170_aa077700ff_m.jpg\"
+      height_s=\"170\" width_s=\"240\" url_m=\"https://live.staticflickr.com/559/32370577170_aa077700ff.jpg\"
+      height_m=\"354\" width_m=\"500\" url_o=\"https://live.staticflickr.com/559/32370577170_b32676baf2_o.jpg\"
+      height_o=\"2381\" width_o=\"3365\" pathalias=\"brightondj\" />\n\t<photo id=\"18089007151\"
+      owner=\"47391132@N00\" secret=\"4111330a40\" server=\"65535\" farm=\"66\" title=\"25-080\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1432573852\"
+      datetaken=\"1972-01-01 00:00:00\" datetakengranularity=\"6\" datetakenunknown=\"0\"
+      ownername=\"ndpa / s. lundeen, archivist\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/18089007151_4111330a40_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/18089007151_4111330a40_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/18089007151_4111330a40_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/18089007151_4111330a40.jpg\"
+      height_m=\"334\" width_m=\"500\" pathalias=\"dboo\" />\n\t<photo id=\"16442381274\"
+      owner=\"66339121@N00\" secret=\"b7f88c4df5\" server=\"7623\" farm=\"8\" title=\"Howhill\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1428399623\"
+      datetaken=\"2015-04-04 16:56:21\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Glenton - Norfolk images\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/7623/16442381274_b7f88c4df5_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/7623/16442381274_b7f88c4df5_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/7623/16442381274_b7f88c4df5_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/7623/16442381274_b7f88c4df5.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/7623/16442381274_38750f9a10_o.jpg\"
+      height_o=\"3840\" width_o=\"5760\" pathalias=\"\" />\n\t<photo id=\"16485504939\"
+      owner=\"114111770@N03\" secret=\"ebda69ee2b\" server=\"8624\" farm=\"9\" title=\"Stembridge
+      windmill\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1425132410\"
+      datetaken=\"2015-02-28 13:51:21\" datetakengranularity=\"0\" datetakenunknown=\"1\"
+      ownername=\"jpotto\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/8624/16485504939_ebda69ee2b_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/8624/16485504939_ebda69ee2b_t.jpg\"
+      height_t=\"100\" width_t=\"67\" url_s=\"https://live.staticflickr.com/8624/16485504939_ebda69ee2b_m.jpg\"
+      height_s=\"240\" width_s=\"160\" url_m=\"https://live.staticflickr.com/8624/16485504939_ebda69ee2b.jpg\"
+      height_m=\"500\" width_m=\"333\" url_o=\"https://live.staticflickr.com/8624/16485504939_a915047c58_o.jpg\"
+      height_o=\"5184\" width_o=\"3456\" pathalias=\"\" />\n\t<photo id=\"16289110077\"
+      owner=\"10211834@N07\" secret=\"68da316d88\" server=\"7419\" farm=\"8\" title=\"The
+      Windmill - Willowstone Modular Project\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1423421232\" datetaken=\"2015-02-08 12:55:40\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"jgg3210\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/7419/16289110077_68da316d88_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/7419/16289110077_68da316d88_t.jpg\"
+      height_t=\"100\" width_t=\"100\" url_s=\"https://live.staticflickr.com/7419/16289110077_68da316d88_m.jpg\"
+      height_s=\"240\" width_s=\"240\" url_m=\"https://live.staticflickr.com/7419/16289110077_68da316d88.jpg\"
+      height_m=\"500\" width_m=\"500\" url_o=\"https://live.staticflickr.com/7419/16289110077_a70165de54_o.jpg\"
+      height_o=\"3456\" width_o=\"3456\" pathalias=\"\" />\n\t<photo id=\"16179483538\"
+      owner=\"53354512@N00\" secret=\"d8f74f20df\" server=\"7408\" farm=\"8\" title=\"Hangman&#039;s
+      Cottage\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"1\" dateupload=\"1422223754\"
+      datetaken=\"2008-06-08 13:21:48\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"tudedude\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/7408/16179483538_d8f74f20df_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/7408/16179483538_d8f74f20df_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/7408/16179483538_d8f74f20df_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/7408/16179483538_d8f74f20df.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/7408/16179483538_ab09ec4e48_o.jpg\"
+      height_o=\"1707\" width_o=\"2560\" pathalias=\"tudedude\" />\n</photos>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1715'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:11:30 GMT
+      Via:
+      - 1.1 163cab6be16ba1fb5ee75dd6beeee0e2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eghMLJTHt4igJuIVMnPD5yPzp4-PyzBm_P41QwCDaCIS1QdaKwEZBQ==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:11:30 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-groups-birdguide--expected_text2.yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-groups-birdguide--expected_text2.yml
@@ -1,0 +1,403 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupGroup&url=https%3A%2F%2Fwww.flickr.com%2Fgroups%2Fbirdguide
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<group
+      id=\"42637302@N00\">\n\t<groupname>Field Guide: Birds of the World</groupname>\n</group>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:38 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xQVpMfYMJrUXO54gcVpilgmwaQX_ylwwJjP27PcoNFN0N7zfU4NRqQ==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:38 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?group_id=42637302%40N00&method=flickr.groups.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<group
+      id=\"42637302@N00\" nsid=\"42637302@N00\" path_alias=\"birdguide\" iconserver=\"7332\"
+      iconfarm=\"8\" lang=\"\" ispoolmoderated=\"0\" photo_limit_opt_out=\"0\" eighteenplus=\"0\"
+      invitation_only=\"0\">\n\t<name>Field Guide: Birds of the World</name>\n\t<description>&lt;i&gt;This
+      is not just another group for people to post random photos of birds, but it
+      is an attempt to build an online &lt;b&gt;Identification Guide&lt;/b&gt; of
+      the birds of the world. The &lt;b&gt;features&lt;/b&gt; of the bird must be
+      clearly visible in your photo and the bird must be &lt;b&gt;positively identified&lt;/b&gt;
+      and &lt;b&gt;&lt;u&gt;tagged&lt;/u&gt; with its &lt;u&gt;scientific (Latin)
+      name&lt;/u&gt;&lt;/b&gt; (see below).&lt;/i&gt;\n\nBEFORE POSTING A PHOTO TO
+      THE POOL, PLEASE REFER TO THE RULES AND GUIDELINES, BELOW (scroll down)!\n\n&lt;i&gt;&lt;a
+      href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157594496099937/&quot;&gt;Para
+      ler as regras em &lt;b&gt;portugu\xEAs&lt;/b&gt;, por favor, &lt;b&gt;carreque
+      aqui&lt;/b&gt;&lt;/a&gt;\n&lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157623615933049/&quot;&gt;Para
+      leer las reglas en &lt;b&gt;espa\xF1ol&lt;/b&gt;, por favor, &lt;b&gt;seleccione
+      aqu\xED&lt;/b&gt;&lt;/a&gt;\n&lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157626606983886/&quot;&gt;Per
+      leggere le regole in &lt;b&gt;italiano&lt;/b&gt;, per favore, &lt;b&gt;clicca
+      qui&lt;/b&gt;&lt;/a&gt;\n&lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157627474634705/&quot;&gt;Pour
+      lire les r\xE8gles en &lt;b&gt;fran\xE7ais&lt;/b&gt;, s&#039;il vous pla\xEEt
+      &lt;b&gt;cliquez ici&lt;/b&gt;&lt;/a&gt;&lt;/i&gt;\n\nThis group is a resource
+      containing photos of &lt;b&gt;over 8000 species of birds&lt;/b&gt;.  You can
+      view all the photos of any particular species by using our &lt;b&gt;hyperlink
+      indexes&lt;/b&gt;. These are alphabetical lists of bird names and by clicking
+      on the name you will see all the photos we hold of that species. They are arranged
+      alphabetically, either by common name, scientific name or group name. Click
+      below to go straight to an index:\n&lt;b&gt;&lt;a href=&quot;https://www.flickr.com/groups/birdguide/discuss/72157659836615634/&quot;&gt;Common
+      name index&lt;/a&gt;&lt;/b&gt; : : : &lt;b&gt;&lt;a href=&quot;https://www.flickr.com/groups/birdguide/discuss/72157661595859350/&quot;&gt;Scientific
+      (Latin) name index&lt;/a&gt;&lt;/b&gt;\n\n&lt;i&gt;Remember, please follow the
+      rules and guidelines below.  Failure to do so may result in your photos being
+      removed from the pool without notice or explanation.&lt;/i&gt;\n&lt;b&gt;Blocking
+      an administrator or moderator of the group will result in you being banned.&lt;/b&gt;\n\nIT
+      SHOULD BE ASSUMED THAT ALL PHOTOGRAPHS IN THIS POOL HAVE ALL RIGHTS RESERVED
+      AND CANNOT BE USED WITHOUT THE EXPRESS PERMISSION OF THE PHOTOGRAPHER.\n\nThere
+      are a number of things YOU can do to help this group.  If you notice someone
+      else has posted a photo to the pool without tagging it, please add the tags
+      yourself; any member can add tags to photos in the pool - you don&#039;t have
+      to be an admin.  Also if you notice that a photo involves a species which does
+      not appear in the hyperlink index, tag the photo FBW:newbird.  This will ensure
+      that the species is added to the index.\n\nWe hope you enjoy, and use, this
+      resource!\n\n&lt;i&gt;&lt;b&gt;GROUP ICON&lt;/b&gt;&lt;/i&gt; - &lt;b&gt;Banded
+      Pitta&lt;/b&gt; &lt;i&gt;Pitta guajana&lt;/i&gt;, by &lt;a href=&quot;http://www.flickr.com/photos/somchai2008/&quot;&gt;somchai@2008&lt;/a&gt;
+      - Khlong thom, Krabi, Thailand.\n&lt;a href=&quot;http://www.flickr.com/photos/somchai2008/3403292257/&quot;&gt;&lt;img
+      src=&quot;http://farm4.static.flickr.com/3633/3403292257_98e14dcc6e_m.jpg&quot;
+      width=&quot;240&quot; height=&quot;240&quot; alt=&quot;Banded Pitta&quot; /&gt;&lt;/a&gt;\n\n&lt;i&gt;======================================================================\nADMIN
+      USE ONLY\nAdmin notes site: &lt;a href=&quot;https://www.flickr.com/groups/1551955@N23/&quot;&gt;www.flickr.com/groups/1551955@N23/&lt;/a&gt;\nOld
+      Admin notes: &lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72057594120386406/page3&quot;&gt;www.flickr.com/groups/birdguide/discuss/72057594120386406...&lt;/a&gt;\nIn
+      order to maintain a true on-line &lt;i&gt;Field Guide: Birds of the World&lt;/i&gt;
+      it is necessary to tag your photos with the correct scientific/latin name per
+      &lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157594382295215/&quot;&gt;Clements
+      5th edition&lt;/a&gt;. Tags make this pool work. Your assistance in tagging
+      your photos is greatly appreciated.  Untagged photos may be removed from the
+      pool.\n======================================================================\n&lt;/i&gt;</description>\n\t<rules>&lt;i&gt;&lt;a
+      href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157594496099937/&quot;&gt;Para
+      ler as regras em &lt;b&gt;portugu\xEAs&lt;/b&gt;, por favor, &lt;b&gt;carreque
+      aqui&lt;/b&gt;&lt;/a&gt;\n&lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157623615933049/&quot;&gt;Para
+      leer las reglas en &lt;b&gt;espa\xF1ol&lt;/b&gt;, por favor, &lt;b&gt;seleccione
+      aqu\xED&lt;/b&gt;&lt;/a&gt;\n&lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157626606983886/&quot;&gt;Per
+      leggere le regole in &lt;b&gt;italiano&lt;/b&gt;, per favore, &lt;b&gt;clicca
+      qui&lt;/b&gt;&lt;/a&gt;\n&lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157627474634705/&quot;&gt;Pour
+      lire les r\xE8gles en &lt;b&gt;fran\xE7ais&lt;/b&gt;, s&#039;il vous pla\xEEt
+      &lt;b&gt;cliquez ici&lt;/b&gt;&lt;/a&gt;&lt;/i&gt;\n\n&lt;i&gt;This is NOT just
+      another group for people to post random photos of birds: the Field Guide is
+      a &lt;b&gt;specialist&lt;/b&gt; group, and participating in it correctly takes
+      &lt;b&gt;time and care&lt;/b&gt; on the part of its members. It is an ongoing
+      project to build an online and indexed &lt;b&gt;identification guide&lt;/b&gt;
+      of the birds of the world. The &lt;b&gt;features&lt;/b&gt; of the bird must
+      be clearly visible in your photo and the bird must be &lt;b&gt;positively identified&lt;/b&gt;
+      and &lt;b&gt;&lt;u&gt;tagged&lt;/u&gt; with its &lt;u&gt;scientific (Latin)
+      name&lt;/u&gt;&lt;/b&gt;.&lt;/i&gt;\n\n\n&lt;b&gt;==========================================================\n
+      RULES AND GUIDELINES FOR POSTING PHOTOS TO THE POOL\n==========================================================&lt;/b&gt;\n\n&lt;u&gt;&lt;b&gt;&lt;i&gt;IDENTIFICATION&lt;/i&gt;&lt;/b&gt;&lt;/u&gt;\n\nIf
+      you don\u2019t know what species your photo shows, &lt;b&gt;do NOT post it yet&lt;/b&gt;
+      - first find out what it is!  You can do so by asking for help in our &lt;a
+      href=&quot;http://www.flickr.com/groups/birdguide/discuss/36682/page41/&quot;&gt;&lt;b&gt;Bird
+      ID Help Line&lt;/b&gt;&lt;/a&gt; thread, or by joining and posting to the &lt;a
+      href=&quot;https://www.flickr.com/groups/bird_id_group/pool/&quot;&gt;&lt;b&gt;Bird
+      Identification Help Group&lt;/b&gt;&lt;/a&gt;. \n\n\n&lt;u&gt;&lt;b&gt;&lt;i&gt;TAGGING&lt;/i&gt;&lt;/b&gt;&lt;/u&gt;\n\nIt
+      is &lt;b&gt;ESSENTIAL&lt;/b&gt; that every photo submitted is &lt;b&gt;tagged
+      with its scientific (Latin) name&lt;/b&gt;.  Failure to do so will mean the
+      photo will not be found when using the &lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157594382295215/&quot;&gt;Hyperlink
+      index&lt;/a&gt; and may result in the photo being removed from the pool. Admins
+      do not have time to tag every photo themselves: YOU must tag your own photos!
+      - this is an essential part of your role as a group-member.\n\nIf you&#039;re
+      not familiar with tagging, see &lt;a href=&quot;https://help.flickr.com/en_us/tag-keywords-in-flickr-BJUJpQoyX&quot;
+      rel=&quot;nofollow&quot;&gt;help.flickr.com/en_us/tag-keywords-in-flickr-BJUJpQoyX&lt;/a&gt;
+      for an explanation of how to do it. \n&lt;i&gt;Note: when tagging bird names,
+      use &lt;b&gt;&amp;quot; &amp;quot;&lt;/b&gt; marks either side of the bird name
+      to ensure that the &lt;b&gt;whole name appears as one tag&lt;/b&gt; - thus with
+      a space (not an underscore or hyphen) between the two words. For example, in
+      the tag-box type &lt;b&gt;&amp;quot;Junco hyemalis&amp;quot;&lt;/b&gt;, NOT
+      &lt;b&gt;Junco hyemalis&lt;/b&gt; or &lt;b&gt;Junco_hyemalis&lt;/b&gt; or &lt;b&gt;Junco-hyemalis&lt;/b&gt;.&lt;/i&gt;\n\nSpecies&#039;
+      scientific names are (sadly) not fixed. This group uses as its standard the
+      list by Clements 2015.  You can check this list at &lt;a href=&quot;http://avibase.bsc-eoc.org/checklist.jsp?list=clements&amp;amp;lang=EN&quot;
+      rel=&quot;nofollow&quot;&gt;Avibase&lt;/a&gt;.\n\nIf you know what the species
+      is but don\u2019t know its scientific name, you can check it at &lt;a href=&quot;http://flickr-fbw.co.uk/search.php&quot;
+      rel=&quot;nofollow&quot;&gt;this site&lt;/a&gt; (along with a variety of useful
+      pool information), or if the species is already in the pool you can check it
+      against our &lt;a href=&quot;http://www.flickr.com/groups/birdguide/discuss/72157594382295215/&quot;&gt;Hyperlink
+      index&lt;/a&gt;.\n\nPlease also ensure that your photos are tagged with the
+      &lt;b&gt;common name&lt;/b&gt; as this is easier for most people to recognise,
+      and there may sometimes be a need to search for photos by common-name tag. \n\n\n&lt;u&gt;&lt;b&gt;&lt;i&gt;LOCATION&lt;/i&gt;&lt;/b&gt;&lt;/u&gt;\n\nPlease
+      always give the location, including a) country and b) region (e.g. state, province)
+      within the country. Do not abbreviate the region/state.\nEven if your photo
+      is placed on the flickr map, it is best to give all this location information
+      in the photo&#039;s caption.\n\n\n&lt;u&gt;&lt;b&gt;&lt;i&gt;WHAT TO POST (and
+      what not to post)&lt;/i&gt;&lt;/b&gt;&lt;/u&gt;\n\nThe idea of this group is
+      that photos should be &lt;b&gt;useful for identification&lt;/b&gt;.  Ideally
+      therefore the photo should be a good close-up of a single bird, showing the
+      whole of the bird. Photos showing only part of the bird are acceptable if the
+      part of the bird they show is helpful for identification.  Also photos of more
+      than one bird are acceptable provided sufficient detail is visible \u2013 large
+      flocks are unlikely to qualify. If you have a large series of wonderful photographs,
+      try to choose the best 2 or maybe 3 which illustrate field characteristics.
+      \ Do not be offended if part of a large series posted to the pool are deleted
+      by administration.\n\nBirds should not be distant, hidden or silhouetted and
+      the markings should be clear. Artistic shots, black &amp;amp; white photos,
+      close-up portraits, etc are not what this group is about.  Be your own judge,
+      but be stricter for common species that are already well-represented in the
+      pool. Photos of more than one bird are acceptable providing at least one of
+      them meets the criteria, but flocks should generally be avoided.  Submitted
+      photos should be  accurate, life-like representations of the bird, so avoid,
+      for example, cloning obscuring vegetation from in front of the bird or excessive
+      colour saturation or other techniques that alter the field appearance.\n\n&lt;b&gt;Wild
+      birds&lt;/b&gt; are preferred to &lt;b&gt;captive&lt;/b&gt; ones. Captive birds
+      are acceptable if we don\u2019t have wild ones in the pool already, but only
+      if they look like wild examples of the species. If you do include a captive
+      bird, please add the &lt;b&gt;tag &#039;captive&#039;&lt;/b&gt; to the photo.\n\nAlthough
+      we do accept &lt;b&gt;domestic&lt;/b&gt; breeds so long as they are in the wild,
+      these are already well-represented so new photos will add little value. We do
+      not accept domestic breeds in captivity.  They should not be tagged with the
+      scientific name to avoid confusion with their wild ancestors \u2013 tag them
+      Domestic and then the species name (e.g. \u201CDomestic Mallard\u201D, \u201CDomestic
+      Greylag Goose\u201D, etc.).\n\nThe Field Guide discourages the photography of
+      &lt;b&gt;breeding birds at the nest&lt;/b&gt; and does not allow such photos
+      - nor photos of &lt;b&gt;nests with eggs&lt;/b&gt; nor of &lt;b&gt;nestlings&lt;/b&gt;.\n\n\n&lt;u&gt;&lt;b&gt;&lt;i&gt;OTHER
+      REQUIREMENTS&lt;/i&gt;&lt;/b&gt;&lt;/u&gt;\n\nWhere known, it is useful if you
+      state the subspecies, gender, age, plumage, morph etc. and tag these.  Tagging
+      the genus is helpful as it allows broader searches.  When tagging &lt;b&gt;subspecies&lt;/b&gt;
+      please tag the full three-part Latin name (e.g. \u201CMotacilla flava flavissima\u201D)
+      but don\u2019t forget to tag just the species name (\u201CMotacilla flava\u201D)
+      as well.\n\n\nThank you for joining, and we look forward to your contributions.</rules>\n\t<members>26133</members>\n\t<pool_count>211406</pool_count>\n\t<topic_count>418</topic_count>\n\t<privacy>3</privacy>\n\t<roles
+      member=\"Member\" moderator=\"Moderator\" admin=\"Admin\" />\n\t<datecreate>2005-05-16
+      08:51:45</datecreate>\n\t<dateactivity>1698142728</dateactivity>\n\t<blast date_blast_added=\"1458407448\"
+      user_id=\"1745985\">In this  &lt;i&gt;Field Guide&lt;/i&gt;, photos &lt;b&gt;MUST&lt;/b&gt;
+      be &lt;b&gt;TAGGED&lt;/b&gt; with the scientific name (Clements 2015 edition).
+      If you don&#039;t know the bird&#039;s identity please ask in the &lt;a href=&quot;https://www.flickr.com/groups/birdguide/discuss/36682/&quot;&gt;Bird
+      ID Help Line&lt;/a&gt; before posting to the pool. To find the scientific name,
+      use &lt;a href=&quot;http://flickr-fbw.co.uk/search1.php&quot; rel=&quot;nofollow&quot;&gt;flickr-fbw.co.uk/search1.php&lt;/a&gt;.
+      &lt;b&gt;Location is also required. UNTAGGED PHOTOS WILL BE DELETED.&lt;/b&gt;</blast>\n\t<throttle
+      count=\"5\" mode=\"day\" />\n\t<restrictions photos_ok=\"1\" videos_ok=\"0\"
+      images_ok=\"1\" screens_ok=\"0\" art_ok=\"0\" virtual_ok=\"0\" safe_ok=\"1\"
+      moderate_ok=\"0\" restricted_ok=\"0\" has_geo=\"0\" />\n</group>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4738'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:39 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - yuq1qU6M_BRH2v48rE-tTpngEbFofOCqpGEiKZ2fH-whOwceQjSZCw==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:39 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Cowner_name%2Cpath_alias%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o&group_id=42637302%40N00&method=flickr.groups.pools.getPhotos&page=1&per_page=10
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+      page=\"1\" pages=\"21146\" perpage=\"10\" total=\"211457\">\n\t<photo id=\"53262429080\"
+      owner=\"150942226@N07\" secret=\"d1d4ef0046\" server=\"65535\" farm=\"66\" title=\"Taiwan
+      Scimitar-babbler\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" ownername=\"longanjiang\"
+      dateadded=\"1698142727\" license=\"0\" dateupload=\"1697449717\" datetaken=\"2023-10-08
+      08:34:14\" datetakengranularity=\"0\" datetakenunknown=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53262429080_d1d4ef0046_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53262429080_d1d4ef0046_t.jpg\"
+      height_t=\"80\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53262429080_d1d4ef0046_m.jpg\"
+      height_s=\"192\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53262429080_d1d4ef0046.jpg\"
+      height_m=\"400\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53262429080_1e3d8bb57e_o.jpg\"
+      height_o=\"2397\" width_o=\"2996\" pathalias=\"\" />\n\t<photo id=\"53241120905\"
+      owner=\"114700825@N07\" secret=\"3d97d77bb4\" server=\"65535\" farm=\"66\" title=\"294.3
+      Alk\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" ownername=\"dirkvanmourik\"
+      dateadded=\"1698131890\" license=\"0\" dateupload=\"1696691252\" datetaken=\"2023-10-01
+      16:05:02\" datetakengranularity=\"0\" datetakenunknown=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53241120905_3d97d77bb4_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53241120905_3d97d77bb4_t.jpg\"
+      height_t=\"56\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53241120905_3d97d77bb4_m.jpg\"
+      height_s=\"135\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53241120905_3d97d77bb4.jpg\"
+      height_m=\"281\" width_m=\"500\" pathalias=\"dirks_birds\" />\n\t<photo id=\"53281743328\"
+      owner=\"14191740@N08\" secret=\"dbba8c8454\" server=\"65535\" farm=\"66\" title=\"Song
+      Thrush (Turdus philomelos), Blackwaterfoot, Arran\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" ownername=\"Terathopius\" dateadded=\"1698126553\" license=\"0\"
+      dateupload=\"1698125666\" datetaken=\"2023-05-19 15:27:01\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53281743328_dbba8c8454_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53281743328_dbba8c8454_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53281743328_dbba8c8454_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53281743328_dbba8c8454.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53281743328_0605136ac5_o.jpg\"
+      height_o=\"2712\" width_o=\"4068\" pathalias=\"nvoaden\" />\n\t<photo id=\"53280569032\"
+      owner=\"14191740@N08\" secret=\"de80db7bf5\" server=\"65535\" farm=\"66\" title=\"Eurasian
+      Skylark (Alauda arvensis), Lockshaw Moss, Fife\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" ownername=\"Terathopius\" dateadded=\"1698126316\" license=\"0\"
+      dateupload=\"1698125666\" datetaken=\"2023-05-13 07:58:00\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53280569032_de80db7bf5_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53280569032_de80db7bf5_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53280569032_de80db7bf5_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53280569032_de80db7bf5.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53280569032_6f62afab0f_o.jpg\"
+      height_o=\"1887\" width_o=\"2831\" pathalias=\"nvoaden\" />\n\t<photo id=\"6804380106\"
+      owner=\"77012150@N08\" secret=\"340b31036d\" server=\"7186\" farm=\"8\" title=\"Juvenile
+      Antarctic Tern DSC_0760\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" ownername=\"Mary
+      Bomford\" dateadded=\"1698123525\" license=\"0\" dateupload=\"1330820420\" datetaken=\"2010-03-06
+      22:14:47\" datetakengranularity=\"0\" datetakenunknown=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/7186/6804380106_340b31036d_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/7186/6804380106_340b31036d_t.jpg\"
+      height_t=\"59\" width_t=\"100\" url_s=\"https://live.staticflickr.com/7186/6804380106_340b31036d_m.jpg\"
+      height_s=\"142\" width_s=\"240\" url_m=\"https://live.staticflickr.com/7186/6804380106_340b31036d.jpg\"
+      height_m=\"295\" width_m=\"500\" url_o=\"https://live.staticflickr.com/7186/6804380106_cc821ba26a_o.jpg\"
+      height_o=\"1794\" width_o=\"3036\" pathalias=\"marybom\" />\n\t<photo id=\"53214672254\"
+      owner=\"22594349@N08\" secret=\"22b679bbdf\" server=\"65535\" farm=\"66\" title=\"White-winged
+      Tern  (Chlidonias leucopterus)\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      ownername=\"Ian N. White\" dateadded=\"1698120949\" license=\"0\" dateupload=\"1695703861\"
+      datetaken=\"2023-09-24 07:26:05\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53214672254_22b679bbdf_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53214672254_22b679bbdf_t.jpg\"
+      height_t=\"72\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53214672254_22b679bbdf_m.jpg\"
+      height_s=\"173\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53214672254_22b679bbdf.jpg\"
+      height_m=\"361\" width_m=\"500\" pathalias=\"ian_white\" />\n\t<photo id=\"53229897350\"
+      owner=\"127058286@N04\" secret=\"2c83709f5b\" server=\"65535\" farm=\"66\" title=\"Buse
+      variable - Common Buzzard (Buteo buteo) - Colombier-Saugnieu - Ferrati\xE8re
+      de Planaise (Rh\xF4ne) France, le 2 octobre 2023\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" ownername=\"Lo\xEFc Le Comte\" dateadded=\"1698116386\" license=\"0\"
+      dateupload=\"1696270512\" datetaken=\"2023-10-02 15:11:59\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53229897350_2c83709f5b_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53229897350_2c83709f5b_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53229897350_2c83709f5b_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53229897350_2c83709f5b.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"\" />\n\t<photo id=\"53281184843\"
+      owner=\"134815842@N03\" secret=\"36280b93e3\" server=\"65535\" farm=\"66\" title=\"Silver-throated
+      Tanager (Tangara icterocephala) Dagua, Colombia 2023-AO5A5477\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" ownername=\"Ricardo Bitran\" dateadded=\"1698104172\"
+      license=\"0\" dateupload=\"1698103280\" datetaken=\"2023-08-30 10:20:06\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53281184843_36280b93e3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53281184843_36280b93e3_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53281184843_36280b93e3_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53281184843_36280b93e3.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"bitranbirdsoftheworld\" />\n\t<photo
+      id=\"53280525311\" owner=\"145466593@N08\" secret=\"03ef9e7802\" server=\"65535\"
+      farm=\"66\" title=\"Red-tailed Hawk\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      ownername=\"barbmerrill2\" dateadded=\"1698091797\" license=\"0\" dateupload=\"1698091293\"
+      datetaken=\"2023-10-19 22:06:21\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53280525311_03ef9e7802_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53280525311_03ef9e7802_t.jpg\"
+      height_t=\"97\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53280525311_03ef9e7802_m.jpg\"
+      height_s=\"233\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53280525311_03ef9e7802.jpg\"
+      height_m=\"486\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53280525311_cb84843fe4_o.jpg\"
+      height_o=\"2841\" width_o=\"2924\" pathalias=\"\" />\n\t<photo id=\"53275243530\"
+      owner=\"78941013@N00\" secret=\"1e57646dc9\" server=\"65535\" farm=\"66\" title=\"Great
+      Skua (Stercorarius skua) Grote jager\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      ownername=\"Ron Winkler nature\" dateadded=\"1698086489\" license=\"0\" dateupload=\"1697915679\"
+      datetaken=\"2022-08-06 18:31:24\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53275243530_1e57646dc9_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53275243530_1e57646dc9_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53275243530_1e57646dc9_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53275243530_1e57646dc9.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"\" />\n</photos>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1820'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:39 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - V5zDvFLQ9BwUQ3-c4F5dk6wAi8dTecgw8gsS3ZqMIz1xEPCksaUPJA==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:39 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-people-blueminds--expected_text3.yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-people-blueminds--expected_text3.yml
@@ -1,0 +1,277 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fblueminds
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"47265398@N04\">\n\t<username>Alexander Lauterbach Photography</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '149'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:08:41 GMT
+      Via:
+      - 1.1 5d9b63835f78c8585a7d3adf703b1d36.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gzHx7gPp9BQidd1bOmMfZoLcrB7P2UeaXdpGQagB4bldmyh3De-Cwg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:08:41 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=47265398%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"47265398@N04\" nsid=\"47265398@N04\" ispro=\"0\" is_deleted=\"0\" iconserver=\"5462\"
+      iconfarm=\"6\" path_alias=\"blueminds\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>Alexander Lauterbach Photography</username>\n\t<realname>Alexander
+      Lauterbach</realname>\n\t<location>Kassel, Germany</location>\n\t<timezone label=\"Amsterdam,
+      Berlin, Bern, Rome, Stockholm, Vienna\" offset=\"+01:00\" timezone_id=\"Europe/Amsterdam\"
+      timezone=\"28\" />\n\t<description>Hi, I&#039;m Alex!\nI&#039;m a self-taught
+      hobby photographer from Germany with a passion for landscape and cityscape photography.\n\nI\u2019ve
+      started with digital photography and my first DSLR back in 2004. In the past
+      couple of years, I\u2019ve more and more fallen in love with landscape photography.
+      For me, photography became the best hobby I can imagine because of the combination
+      of nature and creativity.\nI\u2019m always looking for nice moments and conditions
+      to capture and share. Therefore I really love sunrises and sunsets because It\u2019s
+      the best time of the day with the best light conditions.\n\nMy website: &lt;a
+      href=&quot;https://www.alexander-lauterbach.de&quot; rel=&quot;noreferrer nofollow&quot;&gt;www.alexander-lauterbach.de&lt;/a&gt;\nInstagram:
+      &lt;a href=&quot;http://instagram.com/alex_lauterbach/&quot; rel=&quot;noreferrer
+      nofollow&quot;&gt;instagram.com/alex_lauterbach&lt;/a&gt;\n\n** flickr achievements
+      **\n&lt;a href=&quot;https://www.flickr.com/photos/flickr/galleries/72157706084897874/&quot;&gt;Incredible
+      nominees of Your Best Shot 2018&lt;/a&gt; with photo &amp;quot;winter wonderland&amp;quot;\n&lt;a
+      href=&quot;https://www.flickr.com/photos/flickr/galleries/72157688116208652/?rb=1&quot;&gt;Flickr&#039;s
+      Top-25 photos of 2017&lt;/a&gt; with photo &amp;quot;Lion City&amp;quot;\n&lt;a
+      href=&quot;https://www.flickr.com/photos/flickr/galleries/72157667163347739/&quot;&gt;Top
+      Landscape Photography of 2017&lt;/a&gt; with photo &amp;quot;Bastei Sunrise&amp;quot;\n&lt;a
+      href=&quot;https://www.flickr.com/photos/flickr/galleries/72157690043876864/?rb=1&quot;&gt;Top
+      Architecture Photography of 2017&lt;/a&gt; with photos &amp;quot;Lion City&amp;quot;
+      and &amp;quot;into the city&amp;quot;\n&lt;a href=&quot;https://www.flickr.com/photos/flickrdata/galleries/72157662459622655&quot;&gt;Top
+      photos from Germany in 2015&lt;/a&gt; with photo &amp;quot;once upon a time&amp;quot;\n\n**
+      My Equipment **\nSony Alpha 7R IV\nSony Alpha 7R II\nSony FE 16-35mm F2.8 GM\nSony
+      FE 24-70mm F2.8 GM\nSony FE 70-200mm F2.8 GM\nSony FE 100-400mm F4.5-5.6 GM\nDJI
+      Mavic 2 Pro Drone</description>\n\t<photosurl>https://www.flickr.com/photos/blueminds/</photosurl>\n\t<profileurl>https://www.flickr.com/people/blueminds/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=47233259</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2005-08-02
+      22:38:07</firstdatetaken>\n\t\t<firstdate>1267560528</firstdate>\n\t\t<count>365</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1272'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:08:41 GMT
+      Via:
+      - 1.1 5d9b63835f78c8585a7d3adf703b1d36.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - tnunWEFRcqTczv-i4L1ZPTuTFLMfl_H88l2WIFmAe5a2a1NQseQn5Q==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:08:41 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Cowner_name%2Cpath_alias%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o&method=flickr.people.getPublicPhotos&page=1&per_page=10&user_id=47265398%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+      page=\"1\" pages=\"37\" perpage=\"10\" total=\"365\">\n\t<photo id=\"53257787385\"
+      owner=\"47265398@N04\" secret=\"ed782303af\" server=\"65535\" farm=\"66\" title=\"Magical
+      morning at Orangerie Kassel\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\"
+      dateupload=\"1697296492\" datetaken=\"2023-09-28 06:55:29\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Alexander Lauterbach Photography\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53257787385_ed782303af_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53257787385_ed782303af_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53257787385_ed782303af_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53257787385_ed782303af.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"53191503745\"
+      owner=\"47265398@N04\" secret=\"17ab8888cf\" server=\"65535\" farm=\"66\" title=\"The
+      Heart Nebula in Cassiopeia (IC 1805)\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1694878525\" datetaken=\"2023-09-16 17:33:41\" datetakengranularity=\"0\"
+      datetakenunknown=\"1\" ownername=\"Alexander Lauterbach Photography\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53191503745_17ab8888cf_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53191503745_17ab8888cf_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53191503745_17ab8888cf_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53191503745_17ab8888cf.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"53142273497\"
+      owner=\"47265398@N04\" secret=\"5f1e1dc6b1\" server=\"65535\" farm=\"66\" title=\"Jurassic
+      Coast\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1693065182\"
+      datetaken=\"2023-06-13 08:07:52\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Alexander Lauterbach Photography\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/53142273497_5f1e1dc6b1_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53142273497_5f1e1dc6b1_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53142273497_5f1e1dc6b1_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53142273497_5f1e1dc6b1.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"53095231181\"
+      owner=\"47265398@N04\" secret=\"c8289ca518\" server=\"65535\" farm=\"66\" title=\"Tajinastes\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1691249590\"
+      datetaken=\"2023-06-08 22:03:23\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Alexander Lauterbach Photography\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/53095231181_c8289ca518_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53095231181_c8289ca518_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53095231181_c8289ca518_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53095231181_c8289ca518.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"53046789782\"
+      owner=\"47265398@N04\" secret=\"681ab6ea0c\" server=\"65535\" farm=\"66\" title=\"Golden
+      Sunset over Tenerife\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\"
+      dateupload=\"1689429137\" datetaken=\"2023-06-07 21:46:23\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Alexander Lauterbach Photography\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53046789782_681ab6ea0c_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53046789782_681ab6ea0c_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53046789782_681ab6ea0c_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53046789782_681ab6ea0c.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"52998518188\"
+      owner=\"47265398@N04\" secret=\"579c979859\" server=\"65535\" farm=\"66\" title=\"the
+      monster\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1687620043\"
+      datetaken=\"2023-06-22 16:01:17\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Alexander Lauterbach Photography\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/52998518188_579c979859_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/52998518188_579c979859_t.jpg\"
+      height_t=\"51\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/52998518188_579c979859_m.jpg\"
+      height_s=\"123\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/52998518188_579c979859.jpg\"
+      height_m=\"256\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"52912222845\"
+      owner=\"47265398@N04\" secret=\"36fb00ec7b\" server=\"65535\" farm=\"66\" title=\"Elephant&#039;s
+      Trunk Nebula (IC 1396)\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\"
+      dateupload=\"1684597811\" datetaken=\"2023-05-01 00:00:00\" datetakengranularity=\"4\"
+      datetakenunknown=\"0\" ownername=\"Alexander Lauterbach Photography\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/52912222845_36fb00ec7b_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/52912222845_36fb00ec7b_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/52912222845_36fb00ec7b_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/52912222845_36fb00ec7b.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"52872506511\"
+      owner=\"47265398@N04\" secret=\"77535d5c15\" server=\"65535\" farm=\"66\" title=\"colorful
+      spring morning\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\"
+      dateupload=\"1683301162\" datetaken=\"2023-04-22 06:05:10\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Alexander Lauterbach Photography\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/52872506511_77535d5c15_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/52872506511_77535d5c15_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/52872506511_77535d5c15_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/52872506511_77535d5c15.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"52855453232\"
+      owner=\"47265398@N04\" secret=\"1d46fa4b8e\" server=\"65535\" farm=\"66\" title=\"Lake
+      Edersee dam overflow at sunset\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1682783036\" datetaken=\"2023-04-19 19:54:32\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Alexander Lauterbach Photography\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/52855453232_1d46fa4b8e_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/52855453232_1d46fa4b8e_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/52855453232_1d46fa4b8e_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/52855453232_1d46fa4b8e.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"blueminds\" />\n\t<photo id=\"52819332309\"
+      owner=\"47265398@N04\" secret=\"b327cf64ab\" server=\"65535\" farm=\"66\" title=\"Magical
+      awakening\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1681570769\"
+      datetaken=\"2019-09-08 11:45:24\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Alexander Lauterbach Photography\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/52819332309_b327cf64ab_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/52819332309_b327cf64ab_t.jpg\"
+      height_t=\"100\" width_t=\"80\" url_s=\"https://live.staticflickr.com/65535/52819332309_b327cf64ab_m.jpg\"
+      height_s=\"240\" width_s=\"192\" url_m=\"https://live.staticflickr.com/65535/52819332309_b327cf64ab.jpg\"
+      height_m=\"500\" width_m=\"400\" pathalias=\"blueminds\" />\n</photos>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1228'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:08:41 GMT
+      Via:
+      - 1.1 5d9b63835f78c8585a7d3adf703b1d36.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 1xMpXLldT-bC0Tav4qN8JfemmgWOfNdilmc6UgDffdUGV4jSfugrfg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:08:41 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-photos-aljazeeraenglish-albums-72157626164453131-expected_text1.yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-photos-aljazeeraenglish-albums-72157626164453131-expected_text1.yml
@@ -1,0 +1,318 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Faljazeeraenglish
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"32834977@N03\">\n\t<username>Al Jazeera English</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:38 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - f23d1WgMm_VK9ItVKD3Z2neaAhjCFLFn_QA31aJTFBC46-1Qwqp2xg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=32834977%40N03
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"32834977@N03\" nsid=\"32834977@N03\" ispro=\"0\" is_deleted=\"0\" iconserver=\"3279\"
+      iconfarm=\"4\" path_alias=\"aljazeeraenglish\" has_stats=\"0\" has_adfree=\"0\"
+      has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Al
+      Jazeera English</username>\n\t<realname>Al Jazeera English</realname>\n\t<location
+      />\n\t<timezone label=\"Baghdad\" offset=\"+03:00\" timezone_id=\"Asia/Baghdad\"
+      timezone=\"39\" />\n\t<description>Al Jazeera English is an international news
+      organisation with broadcast centres and bureax around the world.\n\nHere we&#039;ve
+      posted photos from producers and correspondents in the field.\n\nFind out more
+      about what we do at our &lt;strong&gt;&lt;a href=&quot;http://english.aljazeera.net&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;website&lt;/a&gt;&lt;/strong&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/aljazeeraenglish/</photosurl>\n\t<profileurl>https://www.flickr.com/people/aljazeeraenglish/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=32811923</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2008-11-29
+      17:44:41</firstdatetaken>\n\t\t<firstdate>1228516556</firstdate>\n\t\t<count>2339</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '655'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:38 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - aV7ZAnElUWOjNK9oCxsjzpjcSx4bKmWZEOytFWmpFFrLgbpvDzoDGw==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:38 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photosets.getInfo&photoset_id=72157626164453131&user_id=32834977%40N03
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157626164453131\" owner=\"32834977@N03\" username=\"Al Jazeera English\"
+      primary=\"5536044022\" secret=\"7e6f0df667\" server=\"5137\" farm=\"6\" count_views=\"251660\"
+      count_comments=\"1\" count_photos=\"22\" count_videos=\"0\" can_comment=\"0\"
+      date_create=\"1300403604\" date_update=\"1446748881\" photos=\"22\" visibility_can_see_set=\"1\"
+      needs_interstitial=\"0\">\n\t<title>Faces from the Libyan front</title>\n\t<description>Al
+      Jazeera online producer Evan Hill captured these images of Libyan front-line
+      fighters struggling to overthrow longtime ruler Muammar Gaddafi in early March.</description>\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '440'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:38 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DmetB2L8LxDNMDuj6yBC9-r-kQ6bYGYPK-R0_mJTb0BhNHZQyZz1hw==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:38 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Cowner_name%2Cpath_alias%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o&method=flickr.photosets.getPhotos&page=1&per_page=10&photoset_id=72157626164453131&user_id=32834977%40N03
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157626164453131\" primary=\"5536044022\" owner=\"32834977@N03\" ownername=\"Al
+      Jazeera English\" page=\"1\" per_page=\"10\" perpage=\"10\" pages=\"3\" title=\"Faces
+      from the Libyan front\" total=\"22\">\n\t<photo id=\"5536044022\" secret=\"7e6f0df667\"
+      server=\"5137\" farm=\"6\" title=\"IMG_1348\" isprimary=\"1\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402940\" datetaken=\"2011-03-04
+      15:44:00\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Al
+      Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5137/5536044022_7e6f0df667_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5137/5536044022_7e6f0df667_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5137/5536044022_7e6f0df667_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5137/5536044022_7e6f0df667.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5137/5536044022_44d052df5a_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5536043704\" secret=\"4e7448742d\" server=\"5251\" farm=\"6\" title=\"IMG_1318\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402931\"
+      datetaken=\"2011-03-04 15:24:30\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5251/5536043704_4e7448742d_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5251/5536043704_4e7448742d_t.jpg\"
+      height_t=\"100\" width_t=\"67\" url_s=\"https://live.staticflickr.com/5251/5536043704_4e7448742d_m.jpg\"
+      height_s=\"240\" width_s=\"160\" url_m=\"https://live.staticflickr.com/5251/5536043704_4e7448742d.jpg\"
+      height_m=\"500\" width_m=\"333\" url_o=\"https://live.staticflickr.com/5251/5536043704_243949114e_o.jpg\"
+      height_o=\"900\" width_o=\"600\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5535465571\" secret=\"855f26dd4a\" server=\"5173\" farm=\"6\" title=\"IMG_1298\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402926\"
+      datetaken=\"2011-03-04 13:57:31\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5173/5535465571_855f26dd4a_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5173/5535465571_855f26dd4a_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5173/5535465571_855f26dd4a_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5173/5535465571_855f26dd4a.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5173/5535465571_30f3d956a3_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5535465397\" secret=\"646ddea350\" server=\"5299\" farm=\"6\" title=\"IMG_1295\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402920\"
+      datetaken=\"2011-03-04 13:57:18\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5299/5535465397_646ddea350_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5299/5535465397_646ddea350_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5299/5535465397_646ddea350_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5299/5535465397_646ddea350.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5299/5535465397_d401418c42_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5535465269\" secret=\"5e3d78d1e3\" server=\"5094\" farm=\"6\" title=\"IMG_1293\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402916\"
+      datetaken=\"2011-03-04 13:57:10\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5094/5535465269_5e3d78d1e3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5094/5535465269_5e3d78d1e3_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5094/5535465269_5e3d78d1e3_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5094/5535465269_5e3d78d1e3.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5094/5535465269_9ef34d2c3b_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5536043030\" secret=\"56f3c4d5c3\" server=\"5134\" farm=\"6\" title=\"IMG_1292\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402909\"
+      datetaken=\"2011-03-04 13:57:05\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5134/5536043030_56f3c4d5c3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5134/5536043030_56f3c4d5c3_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5134/5536043030_56f3c4d5c3_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5134/5536043030_56f3c4d5c3.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5134/5536043030_db0bb10d20_o.jpg\"
+      height_o=\"533\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5536042908\" secret=\"4dba574cb2\" server=\"5018\" farm=\"6\" title=\"IMG_1242\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402905\"
+      datetaken=\"2011-03-04 12:02:56\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5018/5536042908_4dba574cb2_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5018/5536042908_4dba574cb2_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5018/5536042908_4dba574cb2_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5018/5536042908_4dba574cb2.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5018/5536042908_587059bb78_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5536042662\" secret=\"028306e89d\" server=\"5214\" farm=\"6\" title=\"IMG_1212\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402898\"
+      datetaken=\"2011-03-04 11:35:33\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5214/5536042662_028306e89d_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5214/5536042662_028306e89d_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5214/5536042662_028306e89d_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5214/5536042662_028306e89d.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5214/5536042662_eb7cb4f6ea_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5535464551\" secret=\"2bf01ec987\" server=\"5177\" farm=\"6\" title=\"IMG_1208\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402892\"
+      datetaken=\"2011-03-04 11:34:52\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5177/5535464551_2bf01ec987_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5177/5535464551_2bf01ec987_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5177/5535464551_2bf01ec987_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5177/5535464551_2bf01ec987.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5177/5535464551_b93874ac0f_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n\t<photo
+      id=\"5536042294\" secret=\"55a97b5696\" server=\"5213\" farm=\"6\" title=\"IMG_1207\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" dateupload=\"1300402885\"
+      datetaken=\"2011-03-04 11:34:45\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Al Jazeera English\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5213/5536042294_55a97b5696_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5213/5536042294_55a97b5696_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5213/5536042294_55a97b5696_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5213/5536042294_55a97b5696.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5213/5536042294_fc8941cdf0_o.jpg\"
+      height_o=\"600\" width_o=\"800\" pathalias=\"aljazeeraenglish\" />\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1205'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:38 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - q0uWCDH-jLwf8etOBX7OB1-5ui6EpCv9hIF5RYT1FRFP9m0Fckd_Eg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:38 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-photos-george-galleries-72157621848008117--expected_text4.yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-photos-george-galleries-72157621848008117--expected_text4.yml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?gallery_id=72157621848008117&method=flickr.galleries.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<gallery
+      id=\"5704-72157621848008117\" gallery_id=\"72157621848008117\" url=\"https://www.flickr.com/photos/george/galleries/72157621848008117\"
+      owner=\"34427469121@N01\" username=\"George\" iconserver=\"1\" iconfarm=\"1\"
+      primary_photo_id=\"347360201\" date_create=\"1249665258\" date_update=\"1440667798\"
+      count_photos=\"13\" count_videos=\"0\" count_total=\"13\" count_views=\"12231\"
+      count_comments=\"44\" sort_group=\"\" current_state=\"443b92541e6d4cab8d073342c862702f\"
+      primary_photo_server=\"150\" primary_photo_farm=\"1\" primary_photo_secret=\"a6c0e5721f\">\n\t<title>Photographs
+      I Like of People I Don&#039;t Know</title>\n\t<description />\n\t<cover_photos>\n\t\t<photo
+      url=\"https://live.staticflickr.com/150/347360201_a6c0e5721f_q.jpg\" width=\"150\"
+      height=\"150\" is_primary=\"1\" is_video=\"0\" />\n\t\t<photo url=\"https://live.staticflickr.com/2407/2456288552_3794a1ba27_q.jpg\"
+      width=\"150\" height=\"150\" is_primary=\"0\" is_video=\"0\" />\n\t\t<photo
+      url=\"https://live.staticflickr.com/2387/2178297354_a6f6084173_q.jpg\" width=\"150\"
+      height=\"150\" is_primary=\"0\" is_video=\"0\" />\n\t</cover_photos>\n</gallery>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '538'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:10:12 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fmpKsjKXNvDwWa52l7ZXHh1EMFwyONagmaf0OzlSWwo5nGx85cqaUg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:10:11 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Cowner_name%2Cpath_alias%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o&gallery_id=72157621848008117&method=flickr.galleries.getPhotos&page=1&per_page=10
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+      page=\"1\" pages=\"2\" perpage=\"10\" total=\"13\">\n\t<photo id=\"2456288552\"
+      owner=\"38851157@N00\" secret=\"3794a1ba27\" server=\"2407\" farm=\"3\" title=\"IMG_6834\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" dateupload=\"1209617815\"
+      datetaken=\"2008-04-17 17:35:45\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"locaburg\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/2407/2456288552_3794a1ba27_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/2407/2456288552_3794a1ba27_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/2407/2456288552_3794a1ba27_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/2407/2456288552_3794a1ba27.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/2407/2456288552_b77a3310df_o.jpg\"
+      height_o=\"2912\" width_o=\"4368\" pathalias=\"locaburg\" is_primary=\"0\" has_comment=\"0\"
+      />\n\t<photo id=\"2178297354\" owner=\"19797316@N00\" secret=\"a6f6084173\"
+      server=\"2387\" farm=\"3\" title=\"286\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1199804940\" datetaken=\"2008-01-08 16:05:33\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"jan postma\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/2387/2178297354_a6f6084173_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/2387/2178297354_a6f6084173_t.jpg\"
+      height_t=\"82\" width_t=\"100\" url_s=\"https://live.staticflickr.com/2387/2178297354_a6f6084173_m.jpg\"
+      height_s=\"196\" width_s=\"240\" url_m=\"https://live.staticflickr.com/2387/2178297354_a6f6084173.jpg\"
+      height_m=\"408\" width_m=\"500\" url_o=\"https://live.staticflickr.com/2387/2178297354_2ab749b101_o.jpg\"
+      height_o=\"835\" width_o=\"1024\" pathalias=\"bolus\" is_primary=\"0\" has_comment=\"0\"
+      />\n\t<photo id=\"3506795335\" owner=\"25053835@N03\" secret=\"3f31cfcb3a\"
+      server=\"3602\" farm=\"4\" title=\"Kyohei Inukai in his studio [photograph]
+      / (photographed by Peter A. Juley &amp; Son)\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"7\" dateupload=\"1242396972\" datetaken=\"2005-04-15
+      15:22:15\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Smithsonian
+      Institution\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/3602/3506795335_3f31cfcb3a_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/3602/3506795335_3f31cfcb3a_t.jpg\"
+      height_t=\"100\" width_t=\"81\" url_s=\"https://live.staticflickr.com/3602/3506795335_3f31cfcb3a_m.jpg\"
+      height_s=\"240\" width_s=\"195\" url_m=\"https://live.staticflickr.com/3602/3506795335_3f31cfcb3a.jpg\"
+      height_m=\"500\" width_m=\"405\" url_o=\"https://live.staticflickr.com/3602/3506795335_3c7466d17d_o.jpg\"
+      height_o=\"1300\" width_o=\"1054\" pathalias=\"smithsonian\" is_primary=\"0\"
+      has_comment=\"0\" />\n\t<photo id=\"2830287785\" owner=\"49432667@N00\" secret=\"320f69f56b\"
+      server=\"3208\" farm=\"4\" title=\".\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1220633191\" datetaken=\"2008-09-05 09:47:49\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"snjezana.\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/3208/2830287785_320f69f56b_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/3208/2830287785_320f69f56b_t.jpg\"
+      height_t=\"100\" width_t=\"99\" url_s=\"https://live.staticflickr.com/3208/2830287785_320f69f56b_m.jpg\"
+      height_s=\"240\" width_s=\"237\" url_m=\"https://live.staticflickr.com/3208/2830287785_320f69f56b.jpg\"
+      height_m=\"500\" width_m=\"495\" pathalias=\"snjezanaj\" is_primary=\"0\" has_comment=\"0\"
+      />\n\t<photo id=\"3234578780\" owner=\"35034346209@N01\" secret=\"96dbacdc38\"
+      server=\"3264\" farm=\"4\" title=\"\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1233162889\" datetaken=\"2009-01-27 19:48:00\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Roy\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/3264/3234578780_96dbacdc38_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/3264/3234578780_96dbacdc38_t.jpg\"
+      height_t=\"81\" width_t=\"100\" url_s=\"https://live.staticflickr.com/3264/3234578780_96dbacdc38_m.jpg\"
+      height_s=\"195\" width_s=\"240\" url_m=\"https://live.staticflickr.com/3264/3234578780_96dbacdc38.jpg\"
+      height_m=\"406\" width_m=\"500\" pathalias=\"r6\" is_primary=\"0\" has_comment=\"0\"
+      />\n\t<photo id=\"474277734\" owner=\"42637519@N00\" secret=\"fe4f8375b5\" server=\"209\"
+      farm=\"1\" title=\"Leena the hat lady\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" dateupload=\"1177657206\" datetaken=\"2007-04-26 16:45:46\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Teppo\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/209/474277734_fe4f8375b5_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/209/474277734_fe4f8375b5_t.jpg\"
+      height_t=\"70\" width_t=\"100\" url_s=\"https://live.staticflickr.com/209/474277734_fe4f8375b5_m.jpg\"
+      height_s=\"167\" width_s=\"240\" url_m=\"https://live.staticflickr.com/209/474277734_fe4f8375b5.jpg\"
+      height_m=\"348\" width_m=\"500\" url_o=\"https://live.staticflickr.com/209/474277734_3978a5c142_o.jpg\"
+      height_o=\"2000\" width_o=\"2872\" pathalias=\"teppo\" is_primary=\"0\" has_comment=\"0\"
+      />\n\t<photo id=\"3577982363\" owner=\"51035603587@N01\" secret=\"60a6e94548\"
+      server=\"3398\" farm=\"4\" title=\"27190019\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"0\" dateupload=\"1243693818\" datetaken=\"2009-05-28
+      00:51:41\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"youngna\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/3398/3577982363_60a6e94548_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/3398/3577982363_60a6e94548_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/3398/3577982363_60a6e94548_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/3398/3577982363_60a6e94548.jpg\"
+      height_m=\"333\" width_m=\"500\" pathalias=\"youngna\" is_primary=\"0\" has_comment=\"0\"
+      />\n\t<photo id=\"2179909780\" owner=\"8623220@N02\" secret=\"c263ed2455\" server=\"2243\"
+      farm=\"3\" title=\"Dr. Schreiber of San Augustine giving a typhoid innoculation
+      at a rural school, San Augustine County, Texas  (LOC)\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"7\" dateupload=\"1199852465\" datetaken=\"1939-01-01
+      00:00:00\" datetakengranularity=\"8\" datetakenunknown=\"0\" ownername=\"The
+      Library of Congress\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/2243/2179909780_c263ed2455_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/2243/2179909780_c263ed2455_t.jpg\"
+      height_t=\"77\" width_t=\"100\" url_s=\"https://live.staticflickr.com/2243/2179909780_c263ed2455_m.jpg\"
+      height_s=\"185\" width_s=\"240\" url_m=\"https://live.staticflickr.com/2243/2179909780_c263ed2455.jpg\"
+      height_m=\"385\" width_m=\"500\" url_o=\"https://live.staticflickr.com/2243/2179909780_5c9eacff88_o.jpg\"
+      height_o=\"789\" width_o=\"1024\" pathalias=\"library_of_congress\" is_primary=\"0\"
+      has_comment=\"0\" />\n\t<photo id=\"2870337431\" owner=\"7167652@N06\" secret=\"5a7a77004a\"
+      server=\"3280\" farm=\"4\" title=\"Jiu-Jitsu for Women\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"7\" dateupload=\"1221855093\" datetaken=\"2008-09-19
+      16:11:33\" datetakengranularity=\"0\" datetakenunknown=\"1\" ownername=\"George
+      Eastman Museum\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/3280/2870337431_5a7a77004a_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/3280/2870337431_5a7a77004a_t.jpg\"
+      height_t=\"100\" width_t=\"77\" url_s=\"https://live.staticflickr.com/3280/2870337431_5a7a77004a_m.jpg\"
+      height_s=\"240\" width_s=\"184\" url_m=\"https://live.staticflickr.com/3280/2870337431_5a7a77004a.jpg\"
+      height_m=\"500\" width_m=\"384\" url_o=\"https://live.staticflickr.com/3280/2870337431_69b1b41fd3_o.jpg\"
+      height_o=\"1000\" width_o=\"767\" pathalias=\"george_eastman_house\" is_primary=\"0\"
+      has_comment=\"0\" />\n\t<photo id=\"2048201177\" owner=\"8458540@N06\" secret=\"f85295f2d0\"
+      server=\"2367\" farm=\"3\" title=\"Strong man, c.1910\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"0\" dateupload=\"1195522604\" datetaken=\"2007-11-20
+      14:36:44\" datetakengranularity=\"0\" datetakenunknown=\"1\" ownername=\"National
+      Library of New Zealand\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/2367/2048201177_f85295f2d0_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/2367/2048201177_f85295f2d0_t.jpg\"
+      height_t=\"100\" width_t=\"73\" url_s=\"https://live.staticflickr.com/2367/2048201177_f85295f2d0_m.jpg\"
+      height_s=\"240\" width_s=\"175\" url_m=\"https://live.staticflickr.com/2367/2048201177_f85295f2d0.jpg\"
+      height_m=\"500\" width_m=\"364\" url_o=\"https://live.staticflickr.com/2367/2048201177_75e0f3dba1_o.jpg\"
+      height_o=\"700\" width_o=\"509\" pathalias=\"nationallibrarynz\" is_primary=\"0\"
+      has_comment=\"0\" />\n</photos>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1823'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:10:12 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _9W8Hgol8deL1tKH592Y-w7kVoMtTvRCr9dFLm7T0X0xfDSVjsokaw==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:10:12 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-photos-sdasmarchives-50567413447-expected_text0.yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box.https---www.flickr.com-photos-sdasmarchives-50567413447-expected_text0.yml
@@ -1,0 +1,218 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=50567413447
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+      id=\"50567413447\" secret=\"3ee6d810e8\" server=\"65535\" farm=\"66\" dateuploaded=\"1604519117\"
+      isfavorite=\"0\" license=\"7\" safety_level=\"0\" rotation=\"0\" originalsecret=\"afec74ef45\"
+      originalformat=\"jpg\" views=\"2133\" media=\"photo\">\n\t<owner nsid=\"49487266@N07\"
+      username=\"San Diego Air &amp; Space Museum Archives\" realname=\"SDASM Archives\"
+      location=\"\" iconserver=\"4070\" iconfarm=\"5\" path_alias=\"sdasmarchives\">\n\t\t<gift
+      gift_eligible=\"\" new_flow=\"1\" />\n\t</owner>\n\t<title>KSC-98PC-1602_2</title>\n\t<description>A
+      young, male bobcat balances gingerly on telephone pole cables next to the south-bound
+      lane of Kennedy Parkway. The cat is nocturnal and is seldom observed during
+      the day unless scared from its daytime shelter in the grass or beneath a shrub.
+      Usually found in broken sections of heavily wooded or brushy country, bobcats
+      are reported as common in scrub strand and roadside or weedy grass habitats
+      at KSC. The bobcat is known to inhabit mangrove habitats and will readily swim
+      across small bodies of water. The bobcat occurs across southern Canada then
+      south over the entire United States, except for the midwestern corn belt, to
+      southern Mexico. It is the last large mammalian predator remaining on KSC. Kennedy
+      Space Center is located in the Merritt Island National Wildlife Refuge, which
+      is home to many species of wild animals, including the bobcat.  Image from NASA,
+      originally appeared on this site: &lt;a href=&quot;https://science.ksc.nasa.gov/gallery/photos/&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;science.ksc.nasa.gov/gallery/photos/&lt;/a&gt;
+      \ Reposted by  &lt;a href=&quot;http://www.sandiegoairandspace.org/library/stillimages.html&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;San Diego Air and Space Museum &lt;/a&gt;</description>\n\t<visibility
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1604519117\"
+      taken=\"2020-10-19 16:10:48\" takengranularity=\"0\" takenunknown=\"1\" lastupdate=\"1634688342\"
+      />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+      cancomment=\"1\" canaddmeta=\"1\" />\n\t<usage candownload=\"1\" canblog=\"0\"
+      canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
+      haspeople=\"0\" />\n\t<tags />\n\t<urls>\n\t\t<url type=\"photopage\">https://www.flickr.com/photos/sdasmarchives/50567413447/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1267'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:37 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Opg7BzTDiV15J2JQjTeJyBi8LQDdD2vuarbteZjhmcNJgIkEUE8a0w==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=50567413447
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<sizes
+      canblog=\"0\" canprint=\"0\" candownload=\"1\">\n\t<size label=\"Square\" width=\"75\"
+      height=\"75\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_s.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/sq/\" media=\"photo\"
+      />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_q.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/q/\" media=\"photo\"
+      />\n\t<size label=\"Thumbnail\" width=\"100\" height=\"65\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_t.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/t/\" media=\"photo\"
+      />\n\t<size label=\"Small\" width=\"240\" height=\"157\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_m.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/s/\" media=\"photo\"
+      />\n\t<size label=\"Small 320\" width=\"320\" height=\"209\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_n.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/n/\" media=\"photo\"
+      />\n\t<size label=\"Small 400\" width=\"400\" height=\"262\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_w.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/w/\" media=\"photo\"
+      />\n\t<size label=\"Medium\" width=\"500\" height=\"327\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/m/\" media=\"photo\"
+      />\n\t<size label=\"Medium 640\" width=\"640\" height=\"418\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_z.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/z/\" media=\"photo\"
+      />\n\t<size label=\"Medium 800\" width=\"800\" height=\"523\" source=\"https://live.staticflickr.com/65535/50567413447_3ee6d810e8_c.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/c/\" media=\"photo\"
+      />\n\t<size label=\"Original\" width=\"800\" height=\"523\" source=\"https://live.staticflickr.com/65535/50567413447_afec74ef45_o.jpg\"
+      url=\"https://www.flickr.com/photos/sdasmarchives/50567413447/sizes/o/\" media=\"photo\"
+      />\n</sizes>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '427'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:37 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 23aMWWfPrY2Ujb_arxI5M2YnUN2Ts3PJsfKatGX65iVHXYkSzq6trA==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - python-httpx/0.24.1
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '395'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 24 Oct 2023 11:07:37 GMT
+      Via:
+      - 1.1 30ef06f785f68fc7da8b2baef8948156.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 7BRlXMm41oCuCYDhzrM7d6fLuyyJEkRq1mVuRy-s2RoweFPOXNcUkA==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.57 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 23-Nov-2023 11:07:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,68 @@
+import pytest
+
+
+def test_no_flickr_url_redirects_you_to_homepage(client):
+    resp = client.get("/see_photos")
+
+    assert resp.status_code == 302
+    assert resp.headers['location'] == '/'
+
+
+@pytest.mark.parametrize(
+    ["flickr_url", "expected_text"],
+    [
+        (
+            "https://www.flickr.com/photos/sdasmarchives/50567413447",
+            [b"This URL is", b"a single photo"],
+        ),
+        (
+            "https://www.flickr.com/photos/aljazeeraenglish/albums/72157626164453131",
+            [
+                b"This URL shows the photos in the",
+                b"Faces from the Libyan front",
+                b"album, which was created by",
+                b"Al Jazeera English",
+                b"It contains 22 photos",
+            ],
+        ),
+        (
+            "https://www.flickr.com/groups/birdguide/",
+            [
+                b"This URL shows the photos in the",
+                b"Field Guide: Birds of the World",
+                b"group pool, which contains 211,457 photos",
+            ],
+        ),
+        (
+            "https://www.flickr.com/people/blueminds/",
+            [
+                b"This URL shows the photos taken by",
+                b"Alexander Lauterbach",
+                b"who has posted 365 photos",
+            ],
+        ),
+        (
+            "https://www.flickr.com/photos/george/galleries/72157621848008117/",
+            [
+                b"This URL shows the photos in the",
+                b"Photographs I Like of People I Don't Know",
+                b"gallery",
+                b"which contains 13 photos",
+            ],
+        ),
+        (
+        "https://flickr.com/photos/tags/thatch/",
+        [
+            b"This URL shows photos tagged with",
+            b"thatch"
+        ]
+        )
+    ],
+)
+def test_results_page_shows_info_box(client, api, flickr_url, expected_text):
+    resp = client.get(f"/see_photos?flickr_url={flickr_url}")
+
+    assert resp.status_code == 200
+
+    for text in expected_text:
+        assert text in resp.data.replace(b"&nbsp;", b" ").replace(b"&#39;", b"'")


### PR DESCRIPTION
When I switched to the flickr-url-parser library, I changed some of the return types (e.g. `galleries` became `gallery`), but I forgot to update the templates – and because the Flask app wasn't tested, it wasn't caught until I tried it just now!

I've got a good Flask testing setup for Flickypedia, so I backported some of that to Flinumeratr, wrote some tests for the broken pages, and fixed it!