### PR TITLE
Block entering an empty URL and/or redirect to the homepage

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile dev_requirements.in
 #
-anyio==4.1.0
+anyio==4.2.0
     # via
     #   -r requirements.txt
     #   httpx
-black==23.11.0
+black==23.12.1
     # via -r dev_requirements.in
 blinker==1.7.0
     # via
@@ -27,17 +27,17 @@ click==8.1.7
     #   black
     #   flask
     #   pip-tools
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
     # via
     #   -r dev_requirements.in
     #   pytest-cov
-flake8==6.1.0
+flake8==7.0.0
     # via -r dev_requirements.in
 flask==3.0.0
     # via -r requirements.txt
-flickr-photos-api==1.4.0
+flickr-photos-api==1.7.0
     # via -r requirements.txt
-flickr-url-parser==1.5.0
+flickr-url-parser==1.8.1
     # via
     #   -r requirements.txt
     #   flickr-photos-api
@@ -51,7 +51,7 @@ httpcore==1.0.2
     # via
     #   -r requirements.txt
     #   httpx
-httpx==0.25.2
+httpx==0.26.0
     # via
     #   -r requirements.txt
     #   flickr-photos-api
@@ -88,7 +88,7 @@ mccabe==0.7.0
     # via flake8
 multidict==6.0.4
     # via yarl
-mypy==1.7.1
+mypy==1.8.0
     # via -r dev_requirements.in
 mypy-extensions==1.0.0
     # via
@@ -101,21 +101,21 @@ packaging==23.2
     #   build
     #   gunicorn
     #   pytest
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r dev_requirements.in
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via black
 pluggy==1.3.0
     # via pytest
 pycodestyle==2.11.1
     # via flake8
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -r dev_requirements.in
     #   pytest-cov
@@ -123,12 +123,20 @@ pytest-cov==4.1.0
     # via -r dev_requirements.in
 pyyaml==6.0.1
     # via vcrpy
+silver-nitrate==1.1.0
+    # via
+    #   -r requirements.txt
+    #   flickr-photos-api
 sniffio==1.3.0
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
-typing-extensions==4.8.0
+tenacity==8.2.3
+    # via
+    #   -r requirements.txt
+    #   flickr-photos-api
+typing-extensions==4.9.0
     # via mypy
 vcrpy==5.1.0
     # via -r dev_requirements.in
@@ -140,7 +148,7 @@ wheel==0.42.0
     # via pip-tools
 wrapt==1.16.0
     # via vcrpy
-yarl==1.9.3
+yarl==1.9.4
     # via vcrpy
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-anyio==4.1.0
+anyio==4.2.0
     # via httpx
 blinker==1.7.0
     # via flask
@@ -16,9 +16,9 @@ click==8.1.7
     # via flask
 flask==3.0.0
     # via -r requirements.in
-flickr-photos-api==1.4.0
+flickr-photos-api==1.7.0
     # via -r requirements.in
-flickr-url-parser==1.5.0
+flickr-url-parser==1.8.1
     # via flickr-photos-api
 gunicorn==21.2.0
     # via -r requirements.in
@@ -26,7 +26,7 @@ h11==0.14.0
     # via httpcore
 httpcore==1.0.2
     # via httpx
-httpx==0.25.2
+httpx==0.26.0
     # via
     #   flickr-photos-api
     #   flickr-url-parser
@@ -49,9 +49,13 @@ markupsafe==2.1.3
     #   werkzeug
 packaging==23.2
     # via gunicorn
+silver-nitrate==1.1.0
+    # via flickr-photos-api
 sniffio==1.3.0
     # via
     #   anyio
     #   httpx
+tenacity==8.2.3
+    # via flickr-photos-api
 werkzeug==3.0.1
     # via flask

--- a/src/flinumeratr/app.py
+++ b/src/flinumeratr/app.py
@@ -88,6 +88,11 @@ def see_photos() -> ViewResponse:
     except KeyError:
         return redirect(url_for("index"))
 
+    # If the user enters an empty string, just redirect them back to
+    # the homepage.
+    if not flickr_url:
+        return redirect(url_for("index"))
+
     try:
         parsed_url = parse_flickr_url(flickr_url)
     except UnrecognisedUrl:

--- a/src/flinumeratr/templates/_form.html
+++ b/src/flinumeratr/templates/_form.html
@@ -5,6 +5,7 @@
     type="url"
     name="flickr_url"
     placeholder="https://www.flickr.com/photos/…"
+    required
     {% if flickr_url %}
     value="{{ flickr_url }}"
     {% endif %}

--- a/tests/fixtures/cassettes/test_results_page_shows_info_box[user].yml
+++ b/tests/fixtures/cassettes/test_results_page_shows_info_box[user].yml
@@ -8,12 +8,14 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
       host:
       - api.flickr.com
       user-agent:
       - Flinumeratr/1.1.0 (https://github.com/flickr-foundation/flinumeratr; hello@flickr.org)
     method: GET
-    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fblueminds
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fblueminds%2F
   response:
     content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
       id=\"47265398@N04\">\n\t<username>Alexander Lauterbach Photography</username>\n</user>\n</rsp>\n"
@@ -25,11 +27,11 @@ interactions:
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Mon, 18 Dec 2023 16:13:08 GMT
+      - Fri, 05 Jan 2024 10:18:41 GMT
       Via:
-      - 1.1 081e5088637a101207bef39b8d7f3d4c.cloudfront.net (CloudFront)
+      - 1.1 d4a1f30a438c41cdd21510ef3201c44e.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - hiJQTC-EVAWKKLBf2H30L7uT5q5xotNW5fVZwiJXGjFu5AF8w61Uqg==
+      - _jwHQm8qyPX74NqA7STKnr3kIt6N6C8loe5Y3DitahrHrhx_ACfeMg==
       X-Amz-Cf-Pop:
       - LHR5-P1
       X-Cache:
@@ -39,10 +41,8 @@ interactions:
       server:
       - Apache/2.4.58 (Ubuntu)
       set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Wed, 17-Jan-2024 16:13:06 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Wed, 17-Jan-2024 16:13:06 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+        expires=Sun, 04-Feb-2024 10:18:41 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       vary:
       - Accept-Encoding
       x-frame-options:
@@ -103,16 +103,16 @@ interactions:
     headers:
       Connection:
       - keep-alive
+      Content-Length:
+      - '1271'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Mon, 18 Dec 2023 16:13:08 GMT
-      Transfer-Encoding:
-      - chunked
+      - Fri, 05 Jan 2024 10:18:41 GMT
       Via:
-      - 1.1 081e5088637a101207bef39b8d7f3d4c.cloudfront.net (CloudFront)
+      - 1.1 d4a1f30a438c41cdd21510ef3201c44e.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - bmYdGbQB8S4nqYGuFnWmMO2X0JmlJrpuumDFciyu7bbraC_oCJLmhA==
+      - 2zwMrtO6wnEZv_7N1quLXWGH7ty63TLrVulY6odc88QIWGArRwkT9A==
       X-Amz-Cf-Pop:
       - LHR5-P1
       X-Cache:
@@ -120,16 +120,16 @@ interactions:
       content-encoding:
       - gzip
       server:
-      - openresty
+      - Apache/2.4.58 (Ubuntu)
       set-cookie:
       - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Wed, 17-Jan-2024 16:13:08 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+        expires=Sun, 04-Feb-2024 10:18:41 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       vary:
       - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
       x-robots-tag:
       - noindex
-      x-server:
-      - serverless-proxy-10.78.5.43
     http_version: HTTP/1.1
     status_code: 200
 - request:
@@ -2727,11 +2727,11 @@ interactions:
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Mon, 18 Dec 2023 16:13:09 GMT
+      - Fri, 05 Jan 2024 10:18:42 GMT
       Via:
-      - 1.1 081e5088637a101207bef39b8d7f3d4c.cloudfront.net (CloudFront)
+      - 1.1 d4a1f30a438c41cdd21510ef3201c44e.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - hqxLt8wwLYBnSxmnmvoHGYNJaSk9916FtaeaHgIRBgrRRJCIDSNO3w==
+      - leED3gd9BDhzp6PBC5PjnavtGoA1TNgdGcOb5HyT0_KAYtV8k28OrA==
       X-Amz-Cf-Pop:
       - LHR5-P1
       X-Cache:
@@ -2742,72 +2742,7 @@ interactions:
       - Apache/2.4.58 (Ubuntu)
       set-cookie:
       - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Wed, 17-Jan-2024 16:13:09 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      vary:
-      - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
-      x-robots-tag:
-      - noindex
-    http_version: HTTP/1.1
-    status_code: 200
-- request:
-    body: ''
-    headers:
-      accept:
-      - '*/*'
-      accept-encoding:
-      - gzip, deflate
-      connection:
-      - keep-alive
-      cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
-      host:
-      - api.flickr.com
-      user-agent:
-      - Flinumeratr/1.1.0 (https://github.com/flickr-foundation/flinumeratr; hello@flickr.org)
-    method: GET
-    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
-  response:
-    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
-      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
-      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
-      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
-      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
-      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
-      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
-      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
-      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
-      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
-      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
-      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
-      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
-      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
-      />\n</licenses>\n</rsp>\n"
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '395'
-      Content-Type:
-      - text/xml; charset=utf-8
-      Date:
-      - Mon, 18 Dec 2023 16:13:09 GMT
-      Via:
-      - 1.1 081e5088637a101207bef39b8d7f3d4c.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - pJKKrxD2IvhxNN8C7h1J53Ea2uvnO8LzcOlM-Taz_H91jLTI3MnkXg==
-      X-Amz-Cf-Pop:
-      - LHR5-P1
-      X-Cache:
-      - Miss from cloudfront
-      content-encoding:
-      - gzip
-      server:
-      - Apache/2.4.58 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Wed, 17-Jan-2024 16:13:09 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+        expires=Sun, 04-Feb-2024 10:18:41 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       vary:
       - Accept-Encoding
       x-frame-options:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,3 +113,10 @@ def test_it_doesnt_show_date_taken_if_not_known(
 
     assert resp.status_code == 200
     assert b"taken None" not in resp.data
+
+
+def test_empty_url_redirects_to_homepage(client: FlaskClient) -> None:
+    resp = client.get("/see_photos?flickr_url=")
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"


### PR DESCRIPTION
I spotted this in the app logs – somebody entered the empty URL, and the "see photos" screen was throwing an error. No more!